### PR TITLE
feat(sidebar): allow removing recent documents from sidebar context menu

### DIFF
--- a/Clearance/Models/RecentFilesStore.swift
+++ b/Clearance/Models/RecentFilesStore.swift
@@ -32,6 +32,17 @@ final class RecentFilesStore: ObservableObject {
         persist()
     }
 
+    func remove(path: String) {
+        let priorCount = entries.count
+        entries.removeAll { $0.path == path }
+
+        guard entries.count != priorCount else {
+            return
+        }
+
+        persist()
+    }
+
     private func persist() {
         guard let data = try? JSONEncoder().encode(entries) else {
             return

--- a/Clearance/ViewModels/WorkspaceViewModel.swift
+++ b/Clearance/ViewModels/WorkspaceViewModel.swift
@@ -247,6 +247,13 @@ final class WorkspaceViewModel: NSObject, ObservableObject {
         activeSession?.checkForExternalChanges()
     }
 
+    func removeRecentEntry(path: String) {
+        recentFilesStore.remove(path: path)
+        if selectedRecentPath == path {
+            selectedRecentPath = nil
+        }
+    }
+
     private func bindActiveSession() {
         activeSessionCancellables.removeAll()
         externalChangeTimer?.invalidate()

--- a/Clearance/Views/Sidebar/RecentFilesSidebar.swift
+++ b/Clearance/Views/Sidebar/RecentFilesSidebar.swift
@@ -7,6 +7,7 @@ struct RecentFilesSidebar: View {
     let onOpenFile: () -> Void
     let onSelect: (RecentFileEntry) -> Void
     let onOpenInNewWindow: (RecentFileEntry) -> Void
+    let onRemoveFromSidebar: (RecentFileEntry) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -117,12 +118,26 @@ struct RecentFilesSidebar: View {
                 pasteboard.clearContents()
                 pasteboard.setString(entry.path, forType: .string)
             }
+
+            Divider()
+
+            Button("Remove from Sidebar") {
+                selectedPath = entry.path
+                onRemoveFromSidebar(entry)
+            }
         } else {
             Button("Copy URL") {
                 selectedPath = entry.path
                 let pasteboard = NSPasteboard.general
                 pasteboard.clearContents()
                 pasteboard.setString(entry.fileURL.absoluteString, forType: .string)
+            }
+
+            Divider()
+
+            Button("Remove from Sidebar") {
+                selectedPath = entry.path
+                onRemoveFromSidebar(entry)
             }
         }
     }

--- a/Clearance/Views/WorkspaceView.swift
+++ b/Clearance/Views/WorkspaceView.swift
@@ -34,6 +34,8 @@ struct WorkspaceView: View {
                 selectRecentEntry(entry)
             } onOpenInNewWindow: { entry in
                 popOut(entry: entry)
+            } onRemoveFromSidebar: { entry in
+                removeRecentEntry(entry)
             }
         } detail: {
             Group {
@@ -353,6 +355,10 @@ struct WorkspaceView: View {
         }
 
         _ = viewModel.open(recentEntry: entry)
+    }
+
+    private func removeRecentEntry(_ entry: RecentFileEntry) {
+        viewModel.removeRecentEntry(path: entry.path)
     }
 
     private func popOutDraggedPath(_ path: String) -> Bool {

--- a/ClearanceTests/Models/RecentFilesStoreTests.swift
+++ b/ClearanceTests/Models/RecentFilesStoreTests.swift
@@ -74,4 +74,18 @@ final class RecentFilesStoreTests: XCTestCase {
         XCTAssertEqual(store.entries.filter { $0.path == "https://example.com/docs" }.count, 1)
         XCTAssertNotEqual(store.entries.first?.path, remoteURL.path)
     }
+
+    func testRemovingEntryDeletesOnlyMatchingPath() {
+        let suite = "RecentFilesStoreTests-6"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let store = RecentFilesStore(userDefaults: defaults, storageKey: "recent")
+        store.add(url: URL(fileURLWithPath: "/tmp/one.md"))
+        store.add(url: URL(fileURLWithPath: "/tmp/two.md"))
+
+        store.remove(path: "/tmp/one.md")
+
+        XCTAssertEqual(store.entries.map(\.path), ["/tmp/two.md"])
+    }
 }

--- a/ClearanceTests/ViewModels/WorkspaceViewModelTests.swift
+++ b/ClearanceTests/ViewModels/WorkspaceViewModelTests.swift
@@ -237,6 +237,22 @@ final class WorkspaceViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.activeSession)
     }
 
+    func testRemovingSelectedRecentEntryClearsSidebarSelection() throws {
+        let fileURL = try makeTempMarkdown(contents: "# One")
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let store = RecentFilesStore(userDefaults: defaults, storageKey: "recent")
+        let viewModel = WorkspaceViewModel(recentFilesStore: store)
+
+        viewModel.open(url: fileURL)
+        let path = RecentFileEntry.storageKey(for: fileURL)
+        XCTAssertEqual(viewModel.selectedRecentPath, path)
+
+        viewModel.removeRecentEntry(path: path)
+
+        XCTAssertNil(viewModel.selectedRecentPath)
+        XCTAssertTrue(store.entries.isEmpty)
+    }
+
     private func makeTempMarkdown(contents: String) throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
- add "Remove from Sidebar" action for local and remote recent entries
- implement persisted removal in RecentFilesStore and expose removal via WorkspaceViewModel
- clear selected sidebar entry when the removed item was selected
- cover removal behavior with store and view model unit tests