### PR TITLE
fix(sidebar): respect Reduce Motion in recent files animation

### DIFF
--- a/Clearance/Views/Sidebar/RecentFilesSidebar.swift
+++ b/Clearance/Views/Sidebar/RecentFilesSidebar.swift
@@ -2,6 +2,8 @@ import AppKit
 import SwiftUI
 
 struct RecentFilesSidebar: View {
+    @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+
     let entries: [RecentFileEntry]
     @Binding var selectedPath: String?
     let onOpenFile: () -> Void
@@ -47,7 +49,10 @@ struct RecentFilesSidebar: View {
                 onSelect(entry)
             }
             .listStyle(.sidebar)
-            .animation(.snappy(duration: 0.26), value: entries.map { "\($0.path)|\($0.lastOpenedAt.timeIntervalSinceReferenceDate)" })
+            .animation(
+                accessibilityReduceMotion ? nil : .snappy(duration: 0.26),
+                value: entries.map { "\($0.path)|\($0.lastOpenedAt.timeIntervalSinceReferenceDate)" }
+            )
         }
     }
 


### PR DESCRIPTION
- read `accessibilityReduceMotion` from the SwiftUI environment in `RecentFilesSidebar`
- disable the `.snappy` list animation when Reduce Motion is enabled to improve accessibility