### PR TITLE
Fix sidebar file drag to provide proper file URL type

### DIFF
--- a/Clearance/Views/Sidebar/RecentFilesSidebar.swift
+++ b/Clearance/Views/Sidebar/RecentFilesSidebar.swift
@@ -99,7 +99,7 @@ struct RecentFilesSidebar: View {
         .contextMenu {
             contextMenuActions(for: entry)
         }
-        .draggable(entry.path)
+        .draggable(entry.fileURL)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

- Dragging a file from the sidebar to Finder was creating a text clipping instead of copying the file
- Dragging to apps like Slack did nothing, rather than attaching the file

**Root cause:** `.draggable(entry.path)` puts a plain `String` on the drag pasteboard. Finder and other apps look for the `public.file-url` UTI to identify dragged files — a plain string doesn't satisfy that.

**Fix:** Switch to `.draggable(entry.fileURL)`, which provides a proper `URL` with the `public.file-url` UTI that macOS apps expect.

## Test plan

- [ ] Drag a file from the sidebar to a Finder window — file should copy/move correctly
- [ ] Drag a file from the sidebar into Slack — file should attach to the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)