### PR TITLE
Attempt to fix indentation of checklists.

### DIFF
--- a/Clearance/Resources/render.css
+++ b/Clearance/Resources/render.css
@@ -128,19 +128,21 @@ th {
 .markdown li.task-list-item,
 .markdown li:has(input[type="checkbox"]) {
   list-style: none;
-  padding-left: 1.5em;
-  text-indent: -1.5em;
+  display: flex;
+  align-items: baseline;
+  gap: 0.4em;
+  margin-left: -1.5em;
 }
 
 .markdown li.task-list-item > p,
 .markdown li:has(input[type="checkbox"]) > p {
-  display: inline;
-  margin: 0;
+    margin: 0.5em;
 }
 
 .markdown li.task-list-item > input[type="checkbox"],
 .markdown li:has(input[type="checkbox"]) input[type="checkbox"] {
-  margin: 0 0.4em 0 0;
+  flex-shrink: 0;
+  margin: 0;
   vertical-align: middle;
 }
 


### PR DESCRIPTION
Loving Clearance! However I think checklists could be rendered a bit more stylishly. See the difference between checklists and regular bulleted lists in the before screenshot below. This patch (I think) fixes it. I'm not 100% sure this is the best CSS way to do it but it seems to look okay.

## Before

<img width="838" height="744" alt="image" src="https://github.com/user-attachments/assets/c99e06f2-1930-4ccc-bb93-367cb1e784c3" />

## After

<img width="886" height="842" alt="image" src="https://github.com/user-attachments/assets/6ed4a156-d4db-4ce6-a2ac-69ec390b7b43" />
