### PR TITLE
Don't hardwire table column widths.

### DIFF
--- a/Clearance/Resources/render.css
+++ b/Clearance/Resources/render.css
@@ -47,7 +47,6 @@ td {
 }
 
 th {
-  width: 30%;
   color: var(--muted);
   font-weight: 500;
 }


### PR DESCRIPTION
The current CSS doesn't work well for tables that have more than 3-4 columns. Here's how a table looks in 1.2.2

<img width="871" height="260" alt="image" src="https://github.com/user-attachments/assets/58c05489-74a6-4913-a3df-c2289dcd81b8" />

And here's how it looks with this patch:

<img width="822" height="268" alt="image" src="https://github.com/user-attachments/assets/e2124e1e-8ef1-41b8-bdcc-6ce5bb0cbc35" />
