### PR TITLE
Add "Tidy" button to history sidebar to remove missing files

### DIFF
--- a/Clearance/Models/RecentFilesStore.swift
+++ b/Clearance/Models/RecentFilesStore.swift
@@ -53,6 +53,19 @@ final class RecentFilesStore: ObservableObject {
         persist()
     }
 
+    func removeMissingLocalFiles() {
+        let priorCount = entries.count
+        entries.removeAll { entry in
+            entry.fileURL.isFileURL && !FileManager.default.fileExists(atPath: entry.fileURL.path)
+        }
+
+        guard entries.count != priorCount else {
+            return
+        }
+
+        persist()
+    }
+
     func remove(path: String) {
         let priorCount = entries.count
         entries.removeAll { $0.path == path }

--- a/Clearance/ViewModels/WorkspaceViewModel.swift
+++ b/Clearance/ViewModels/WorkspaceViewModel.swift
@@ -43,6 +43,7 @@ final class WorkspaceViewModel: NSObject, ObservableObject {
     private let openPanelService: OpenPanelServicing
     private let appSettings: AppSettings
     private let remoteDocumentLoader: @Sendable (URL) async throws -> RemoteDocument
+    private var cancellables: Set<AnyCancellable> = []
     private var activeSessionCancellables: Set<AnyCancellable> = []
     private var externalChangeTimer: Timer?
     private weak var monitoredSession: DocumentSession?
@@ -67,6 +68,10 @@ final class WorkspaceViewModel: NSObject, ObservableObject {
         mode = appSettings.defaultOpenMode
         windowTitle = "Clearance"
         super.init()
+
+        recentFilesStore.objectWillChange
+            .sink { [weak self] in self?.objectWillChange.send() }
+            .store(in: &cancellables)
     }
 
     deinit {

--- a/Clearance/Views/Sidebar/RecentFilesSidebar.swift
+++ b/Clearance/Views/Sidebar/RecentFilesSidebar.swift
@@ -11,6 +11,7 @@ struct RecentFilesSidebar: View {
     let onSelect: (RecentFileEntry) -> Void
     let onOpenInNewWindow: (RecentFileEntry) -> Void
     let onRemoveFromSidebar: (RecentFileEntry) -> Void
+    let onCleanHistory: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -25,6 +26,13 @@ struct RecentFilesSidebar: View {
                 }
                 .buttonStyle(.borderless)
                 .controlSize(.small)
+
+                Button(action: onCleanHistory) {
+                    Label("Tidy", systemImage: "sparkles")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .help("Remove entries for files that no longer exist")
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 8)

--- a/Clearance/Views/WorkspaceView.swift
+++ b/Clearance/Views/WorkspaceView.swift
@@ -44,6 +44,8 @@ struct WorkspaceView: View {
                 popOut(entry: entry)
             } onRemoveFromSidebar: { entry in
                 removeRecentEntry(entry)
+            } onCleanHistory: {
+                viewModel.recentFilesStore.removeMissingLocalFiles()
             }
         } detail: {
             Group {


### PR DESCRIPTION
Maybe this is just a me thing but when working with Claude I make a lot of .md files that then get moved or deleted. So this feature gives me a one click way to clean up files from the sidebar that don't exist any more. Feels useful to me but I understand that maybe there are deeper thoughts about the sidebar that could be thought than this quick fix. But in case you want it, here it is.