### PR TITLE
Render inline code within headings

### DIFF
--- a/Clearance/Views/Render/RenderedMarkdownHTMLFormatter.swift
+++ b/Clearance/Views/Render/RenderedMarkdownHTMLFormatter.swift
@@ -55,7 +55,9 @@ struct RenderedMarkdownHTMLFormatter: MarkupWalker {
     }
 
     mutating func visitHeading(_ heading: Heading) {
-        result += "<h\(heading.level)>\(escapeText(heading.plainText))</h\(heading.level)>\n"
+        result += "<h\(heading.level)>"
+        descendInto(heading)
+        result += "</h\(heading.level)>\n"
     }
 
     mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) {


### PR DESCRIPTION
Use descendInto() instead of plainText so backtick spans in headings produce `<code>` elements rather than being flattened to plain text.

This seems right to me and works in my documents but I don't know if there are subtleties that I'm unaware of.