### PR TITLE
Fix CLI symlink resolution

### DIFF
--- a/Clearance/Services/ClearanceCommandLineTool.swift
+++ b/Clearance/Services/ClearanceCommandLineTool.swift
@@ -14,6 +14,7 @@ enum ClearanceCommandLineTool {
 
     static func appBundleURL(forHelperExecutableURL url: URL) -> URL? {
         let appURL = url
+            .resolvingSymlinksInPath()
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .deletingLastPathComponent()

--- a/ClearanceTests/Services/ClearanceCommandLineToolTests.swift
+++ b/ClearanceTests/Services/ClearanceCommandLineToolTests.swift
@@ -11,6 +11,20 @@ final class ClearanceCommandLineToolTests: XCTestCase {
         XCTAssertEqual(helperURL.path, bundleURL.appending(path: "Contents/Helpers/clearance").path)
     }
 
+    func testAppBundleURLResolvesWhenHelperIsSymlinked() throws {
+        let bundleURL = try makeBundle(helperName: ClearanceCommandLineTool.name)
+        let helperURL = bundleURL.appending(path: "Contents/Helpers/\(ClearanceCommandLineTool.name)")
+
+        let symlinkURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: helperURL)
+        defer { try? FileManager.default.removeItem(at: symlinkURL) }
+
+        let appURL = try XCTUnwrap(ClearanceCommandLineTool.appBundleURL(forHelperExecutableURL: symlinkURL))
+
+        XCTAssertEqual(appURL.standardized, bundleURL.standardized)
+    }
+
     func testPrepareDocumentURLsResolvesRelativePathsAndCreatesMissingMarkdownFiles() throws {
         let currentDirectoryURL = try makeDirectory()
         let missingFileURL = currentDirectoryURL.appending(path: "notes.md")


### PR DESCRIPTION
## Summary

- `Bundle.main.executableURL` returns the symlink path when the binary is invoked via a symlink, causing `appBundleURL` to traverse the wrong path and fail its `.app` extension guard
- Adds `.resolvingSymlinksInPath()` before the three `deletingLastPathComponent()` calls in `appBundleURL(forHelperExecutableURL:)`
- Adds a regression test that symlinks the helper outside the bundle and asserts the bundle URL still resolves correctly

Fixes #25.

## Test plan

- [ ] `xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS'` passes with 0 failures
- [ ] `testAppBundleURLResolvesWhenHelperIsSymlinked` passes (was failing before the fix)
- [ ] Manually verify: `ln -s ./Clearance.app/Contents/Helpers/clearance ./clearance-symlink && ./clearance-symlink` launches the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)