### PR TITLE
Fix test build configuration for Xcode 26 explicit module builds

### DIFF
--- a/Clearance.xcodeproj/project.pbxproj
+++ b/Clearance.xcodeproj/project.pbxproj
@@ -636,7 +636,6 @@
 				};
 			};
 			buildConfigurationList = ED66D83F11FC4A029E6C5E1A /* Build configuration list for PBXProject "Clearance" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -651,6 +650,7 @@
 				46FDBA5BD89FAFB875CE42F8 /* XCRemoteSwiftPackageReference "Yams" */,
 			);
 			preferredProjectObjectVersion = 77;
+			productRefGroup = 16545B835C0A0207E7B147B6 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -800,6 +800,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.jesse.ClearanceTests;
 				SDKROOT = macosx;
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
+				SWIFT_INCLUDE_PATHS = "$(OBJROOT)/Clearance.build/$(CONFIGURATION)/Clearance.build/Objects-normal/$(NATIVE_ARCH_ACTUAL)";
 				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Clearance.app/Contents/MacOS/Clearance";
 			};
@@ -827,6 +829,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 12;
+				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = Clearance/App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -848,6 +851,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 12;
+				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = Clearance/App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -875,6 +879,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.jesse.ClearanceTests;
 				SDKROOT = macosx;
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
+				SWIFT_INCLUDE_PATHS = "$(OBJROOT)/Clearance.build/$(CONFIGURATION)/Clearance.build/Objects-normal/$(NATIVE_ARCH_ACTUAL)";
 				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Clearance.app/Contents/MacOS/Clearance";
 			};

--- a/project.yml
+++ b/project.yml
@@ -32,6 +32,7 @@ targets:
         CURRENT_PROJECT_VERSION: 12
         SPARKLE_FEED_URL: ""
         SPARKLE_PUBLIC_ED_KEY: ""
+        DEFINES_MODULE: YES
     dependencies:
       - package: Yams
       - package: Markdown
@@ -66,6 +67,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.jesse.ClearanceTests
         GENERATE_INFOPLIST_FILE: YES
         SWIFT_VERSION: 6.0
+        SWIFT_ENABLE_EXPLICIT_MODULES: NO
+        SWIFT_INCLUDE_PATHS: $(OBJROOT)/Clearance.build/$(CONFIGURATION)/Clearance.build/Objects-normal/$(NATIVE_ARCH_ACTUAL)
 schemes:
   Clearance:
     build:


### PR DESCRIPTION
## Summary

Tests have been broken since v1.2.5 when run via `xcodebuild` on macOS 26 / Xcode 26.3. Running the test suite per `DEVELOPMENT.md` produces:

```
error: Unable to find module dependency: 'Clearance'
  → ClearanceTests/Services/AddressBarFormatterTests.swift:2:18
```

The root cause is that Xcode 26's explicit module build system pre-scans all imports before compilation begins. For app targets, the `.swiftmodule` is written to the build intermediates directory rather than the products directory. The explicit module scanner searches products and fails to find `Clearance.swiftmodule`, even though the `Clearance` target itself builds successfully.

## Changes

Three build settings in `project.yml` (and the regenerated `project.pbxproj`):

- **`DEFINES_MODULE = YES`** on the `Clearance` target — instructs the build system to produce a proper importable Swift module for the app target
- **`SWIFT_ENABLE_EXPLICIT_MODULES = NO`** on `ClearanceTests` — disables the explicit module build system for the test bundle, falling back to implicit module resolution which respects `SWIFT_INCLUDE_PATHS`
- **`SWIFT_INCLUDE_PATHS`** on `ClearanceTests` — points to `$(OBJROOT)/Clearance.build/$(CONFIGURATION)/Clearance.build/Objects-normal/$(NATIVE_ARCH_ACTUAL)`, where `Clearance.swiftmodule` is produced during the build

## Environment

Reproduced and fixed on:
- **macOS:** 26.4 (Darwin 25.4.0)
- **Xcode:** 26.3 (Build 17C529)

## Test plan

- [ ] `xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS'` completes with 0 failures (previously failed to build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)