### PR TITLE
Prompt for admin password when /usr/local/bin is not writable

### DIFF
--- a/Clearance.xcodeproj/project.pbxproj
+++ b/Clearance.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		B17723F60D752C198BEEC72F /* RemoteDocumentFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AF9E28DED82F66BCB2BAC3 /* RemoteDocumentFetcherTests.swift */; };
 		B4D3A46870C3355E735903BB /* RecentFileEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FAC0079CAC219C4FCCA548 /* RecentFileEntryTests.swift */; };
 		B6E092FD4F09A47E7C1CA01D /* RenderedHTMLBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA818FBB74D40D57CAFFD0BE /* RenderedHTMLBuilderTests.swift */; };
+		B847F78BB9DC1AEDBAA82189 /* ClearanceInstallHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6AD84132CFF75948B3416C /* ClearanceInstallHelperTests.swift */; };
 		B92216E2C64C1F77FB9194E5 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792005A274FD1A79B3FF667 /* SettingsView.swift */; };
 		B95EA8B4970673C5C1ACFFA1 /* SparkleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B9674E22E02C1ADBB94FAB /* SparkleConfiguration.swift */; };
 		C0D9F459C94D98596C1519A5 /* DocumentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47364E84B7FF3916B7C3E787 /* DocumentSession.swift */; };
@@ -159,6 +160,7 @@
 		34C4A19B6F698407847DF441 /* Clearance.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Clearance.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C69E97E0EFF74A0B90691EC /* meta.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = meta.min.js; sourceTree = "<group>"; };
 		3CE698AA1B475E5E066FBD7E /* OutlineSplitViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineSplitViewControllerTests.swift; sourceTree = "<group>"; };
+		3D6AD84132CFF75948B3416C /* ClearanceInstallHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearanceInstallHelperTests.swift; sourceTree = "<group>"; };
 		3D7E23177932E65E43D9F43D /* RecentFilesStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesStoreTests.swift; sourceTree = "<group>"; };
 		3E733E5C66D66FE7E34C2957 /* OutlineSplitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineSplitView.swift; sourceTree = "<group>"; };
 		41316671B9239418D2FEFB25 /* WorkspaceMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMode.swift; sourceTree = "<group>"; };
@@ -470,6 +472,7 @@
 				08D1A3EA9745A77719072467 /* AddressBarFormatterTests.swift */,
 				D260FF64F7D58426825A82FA /* ClearanceCommandLineInstallerTests.swift */,
 				135B508EEFF411B7BB6ED494 /* ClearanceCommandLineToolTests.swift */,
+				3D6AD84132CFF75948B3416C /* ClearanceInstallHelperTests.swift */,
 				5AB530C2B9FBDB33BC73C4EB /* LocalNavigationPolicyTests.swift */,
 				71149C72CDE405EF2F562E7C /* MarkdownLinkRouterTests.swift */,
 				F69F1DE5EB87BE702524F527 /* ReleaseNotesCatalogTests.swift */,
@@ -772,6 +775,7 @@
 				364C0123C332CFDF304FBBF7 /* AppSettingsTests.swift in Sources */,
 				C5D1B8ED3F84FDA76182A98C /* ClearanceCommandLineInstallerTests.swift in Sources */,
 				99B470E4B5FEEC694853E793 /* ClearanceCommandLineToolTests.swift in Sources */,
+				B847F78BB9DC1AEDBAA82189 /* ClearanceInstallHelperTests.swift in Sources */,
 				1D84B286C1B55B6CAECFDB30 /* DemoCorpusRenderingTests.swift in Sources */,
 				21D0661B93449ACC0E03F882 /* DocumentSessionTests.swift in Sources */,
 				D0FDE4FA090E278F8A6C0237 /* EditorTemplateTests.swift in Sources */,

--- a/Clearance.xcodeproj/project.pbxproj
+++ b/Clearance.xcodeproj/project.pbxproj
@@ -636,7 +636,6 @@
 				};
 			};
 			buildConfigurationList = ED66D83F11FC4A029E6C5E1A /* Build configuration list for PBXProject "Clearance" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -651,6 +650,7 @@
 				46FDBA5BD89FAFB875CE42F8 /* XCRemoteSwiftPackageReference "Yams" */,
 			);
 			preferredProjectObjectVersion = 77;
+			productRefGroup = 16545B835C0A0207E7B147B6 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -800,6 +800,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.jesse.ClearanceTests;
 				SDKROOT = macosx;
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
+				SWIFT_INCLUDE_PATHS = "$(OBJROOT)/Clearance.build/$(CONFIGURATION)/Clearance.build/Objects-normal/$(NATIVE_ARCH_ACTUAL)";
 				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Clearance.app/Contents/MacOS/Clearance";
 			};
@@ -827,6 +829,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 12;
+				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = Clearance/App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -848,6 +851,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 12;
+				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = Clearance/App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -875,6 +879,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.jesse.ClearanceTests;
 				SDKROOT = macosx;
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
+				SWIFT_INCLUDE_PATHS = "$(OBJROOT)/Clearance.build/$(CONFIGURATION)/Clearance.build/Objects-normal/$(NATIVE_ARCH_ACTUAL)";
 				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Clearance.app/Contents/MacOS/Clearance";
 			};

--- a/Clearance.xcodeproj/project.pbxproj
+++ b/Clearance.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		08B201BBBD3D983E5EABDAE6 /* NewMarkdownDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94989B370EBA22EA6B70516B /* NewMarkdownDocument.swift */; };
 		0C30245DB5F31FDF11648B22 /* editor.html in Resources */ = {isa = PBXBuildFile; fileRef = 6B22E26DA34D118F0F697066 /* editor.html */; };
 		117C2FE71D2456C221D6406F /* DocumentSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F90C1DAF38DAA3654AC006 /* DocumentSurfaceView.swift */; };
+		117C6E8F555298C643E9914C /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D94D4BBD9E9A6687F609141E /* Security.framework */; };
 		11AD2934690832F4BD328F45 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13D2F81D6FF064EF2A8D046E /* Assets.xcassets */; };
 		1D2A93755ECD7CF7E00C4FA3 /* WorkspaceMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41316671B9239418D2FEFB25 /* WorkspaceMode.swift */; };
 		1D84B286C1B55B6CAECFDB30 /* DemoCorpusRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE8467DFB2ADBD5A5B6243C /* DemoCorpusRenderingTests.swift */; };
@@ -31,11 +32,15 @@
 		39D0221F4BDA6535F566C2D7 /* WorkspaceToolbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBCC97292840D7215ED6ED9A /* WorkspaceToolbarTests.swift */; };
 		3B0E388AA76D6BE278193E56 /* FrontmatterParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB17ADA4814DFD7553DA44E /* FrontmatterParser.swift */; };
 		4382AEE3929E50AB959B5BB0 /* NewMarkdownDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94989B370EBA22EA6B70516B /* NewMarkdownDocument.swift */; };
+		4534C8089BA37FF80EE2C7BB /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531CB129221E26CE3CF922F0 /* main.swift */; };
 		45B41A0209726F465DCE5AA8 /* meta.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 3C69E97E0EFF74A0B90691EC /* meta.min.js */; };
 		4BE178727B68197CB107DC84 /* katex.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 2B7FBE350DF59254B01CB175 /* katex.min.js */; };
 		4C058C1A4212F64ABDCB1AAE /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111BF55C7FCD8D9B414000B3 /* AppSettings.swift */; };
+		5290372BF856623C18B969F4 /* HelperInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A476D3D313A0605CAFFECB /* HelperInstaller.swift */; };
 		52BCD534D92EC21C9413E3A7 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = D9E5334BFE4D4625AE23A1D2 /* CHANGELOG.md */; };
 		534727D84224D3FC3480E130 /* ClearanceCommandLineTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = D506149BCCF27E70A1138F29 /* ClearanceCommandLineTool.swift */; };
+		5A8997D2F75948982E75E0DD /* ClearanceInstallHelper in Embed Dependencies */ = {isa = PBXBuildFile; fileRef = 1A7F9312FC0EEDCF296BDA84 /* ClearanceInstallHelper */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		61790119A8642AEF6810AFE5 /* HelperInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A476D3D313A0605CAFFECB /* HelperInstaller.swift */; };
 		6401A4589D5A1F5837D18763 /* FrontmatterParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DA3D7DC3A83D74FD71C6CD /* FrontmatterParserTests.swift */; };
 		6C6152910A59A689E7D65FE3 /* ClearanceApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1D94EEFD55E5B462789CF5 /* ClearanceApp.swift */; };
 		6DA244D482A2A60CDE2E69D1 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 38286B5A8D5104241F0BCC6C /* Sparkle */; };
@@ -92,6 +97,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		157644D69837994F2F69E14B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 71D601864E4D2AADDC25175D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9EE20F5D9C219CA6C2119114;
+			remoteInfo = ClearanceInstallHelper;
+		};
 		8FFF9FE04658025A2F240301 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 71D601864E4D2AADDC25175D /* Project object */;
@@ -116,6 +128,7 @@
 			dstSubfolderSpec = 1;
 			files = (
 				22700337F91BAF94DE42ECBB /* ClearanceCLI in Embed Dependencies */,
+				5A8997D2F75948982E75E0DD /* ClearanceInstallHelper in Embed Dependencies */,
 			);
 			name = "Embed Dependencies";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -132,6 +145,7 @@
 		135B508EEFF411B7BB6ED494 /* ClearanceCommandLineToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearanceCommandLineToolTests.swift; sourceTree = "<group>"; };
 		13D2F81D6FF064EF2A8D046E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		161EFA6EC4B9CF198693D20C /* auto-render.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "auto-render.min.js"; sourceTree = "<group>"; };
+		1A7F9312FC0EEDCF296BDA84 /* ClearanceInstallHelper */ = {isa = PBXFileReference; includeInIndex = 0; path = ClearanceInstallHelper; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F6B8061492692C913AD22DB /* EditorTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTemplateTests.swift; sourceTree = "<group>"; };
 		268A560042FDA86DCDDEC8C9 /* RecentFilesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesStore.swift; sourceTree = "<group>"; };
 		26DB01E6A857AB360BD2A10B /* AddressBarSearchToolbarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBarSearchToolbarControllerTests.swift; sourceTree = "<group>"; };
@@ -153,6 +167,7 @@
 		49B450F382B0AA1974EF331C /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		4B9E5E4A4287EFEE1395E81E /* xml.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = xml.min.js; sourceTree = "<group>"; };
 		4DF9F3622F8AB86F4333A0BA /* EditorUndoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorUndoTests.swift; sourceTree = "<group>"; };
+		531CB129221E26CE3CF922F0 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		55F00C171DF86F249DD81368 /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
 		5AB530C2B9FBDB33BC73C4EB /* LocalNavigationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNavigationPolicyTests.swift; sourceTree = "<group>"; };
 		5BAB78E34398153FEC9E98E6 /* RecentFileEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFileEntry.swift; sourceTree = "<group>"; };
@@ -173,6 +188,7 @@
 		7E1687B28E91B80164C0B4D2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		80E283907E1D0642A9D67E41 /* RenderedHTMLBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderedHTMLBuilder.swift; sourceTree = "<group>"; };
 		82DA3D7DC3A83D74FD71C6CD /* FrontmatterParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmatterParserTests.swift; sourceTree = "<group>"; };
+		83A476D3D313A0605CAFFECB /* HelperInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperInstaller.swift; sourceTree = "<group>"; };
 		843ADCEF5329AD8118563A9F /* AppDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateTests.swift; sourceTree = "<group>"; };
 		8792005A274FD1A79B3FF667 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		8FBE6D473B72CA81BDCBED00 /* LocalNavigationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNavigationPolicy.swift; sourceTree = "<group>"; };
@@ -195,6 +211,7 @@
 		D260FF64F7D58426825A82FA /* ClearanceCommandLineInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearanceCommandLineInstallerTests.swift; sourceTree = "<group>"; };
 		D4E041D19FB916AF04A2BD96 /* RemoteDocumentFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteDocumentFetcher.swift; sourceTree = "<group>"; };
 		D506149BCCF27E70A1138F29 /* ClearanceCommandLineTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearanceCommandLineTool.swift; sourceTree = "<group>"; };
+		D94D4BBD9E9A6687F609141E /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		D9E5334BFE4D4625AE23A1D2 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		DA529592EDFA82E161C9097C /* FileIO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIO.swift; sourceTree = "<group>"; };
 		E3B013A31889331945B8CEA0 /* OpenPanelService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPanelService.swift; sourceTree = "<group>"; };
@@ -209,6 +226,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		5DF27BDBD35BC3BE89B32021 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				117C6E8F555298C643E9914C /* Security.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		72CE02DAB6B27232B3682375 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -281,6 +306,7 @@
 			children = (
 				34C4A19B6F698407847DF441 /* Clearance.app */,
 				75F4D1D16DF2C7F39C75EE20 /* ClearanceCLI */,
+				1A7F9312FC0EEDCF296BDA84 /* ClearanceInstallHelper */,
 				9A2B8249245BF603D879F69A /* ClearanceTests.xctest */,
 			);
 			name = Products;
@@ -344,7 +370,9 @@
 				D9E5334BFE4D4625AE23A1D2 /* CHANGELOG.md */,
 				D183F7BE0F49CD9177BF3CB2 /* Clearance */,
 				140F64D45C99B750B75FA745 /* ClearanceCLI */,
+				EB999B0DB3927840210EC28A /* ClearanceInstallHelper */,
 				109C929919AAE837B27A43BF /* ClearanceTests */,
+				D552847F62C95EA8A1769835 /* Frameworks */,
 				16545B835C0A0207E7B147B6 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -526,6 +554,14 @@
 			path = Services;
 			sourceTree = "<group>";
 		};
+		D552847F62C95EA8A1769835 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D94D4BBD9E9A6687F609141E /* Security.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		DDAAA03B6E64DFA35F05D492 /* vendor */ = {
 			isa = PBXGroup;
 			children = (
@@ -543,6 +579,15 @@
 				AE323A2BC00DCF2D5C3ED824 /* WorkspaceViewModelTests.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		EB999B0DB3927840210EC28A /* ClearanceInstallHelper */ = {
+			isa = PBXGroup;
+			children = (
+				83A476D3D313A0605CAFFECB /* HelperInstaller.swift */,
+				531CB129221E26CE3CF922F0 /* main.swift */,
+			);
+			path = ClearanceInstallHelper;
 			sourceTree = "<group>";
 		};
 		FCDC7B62F2B46C0FAF80C182 /* Models */ = {
@@ -575,6 +620,7 @@
 			);
 			dependencies = (
 				BEA4828002994425BE2876C3 /* PBXTargetDependency */,
+				B6DDED29E1185BD41FB7D3B0 /* PBXTargetDependency */,
 			);
 			name = Clearance;
 			packageProductDependencies = (
@@ -621,6 +667,24 @@
 			productReference = 75F4D1D16DF2C7F39C75EE20 /* ClearanceCLI */;
 			productType = "com.apple.product-type.tool";
 		};
+		9EE20F5D9C219CA6C2119114 /* ClearanceInstallHelper */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A47438F3F0A9DD6AA39C2F22 /* Build configuration list for PBXNativeTarget "ClearanceInstallHelper" */;
+			buildPhases = (
+				E5E464F70A828EBB53E7AA83 /* Sources */,
+				5DF27BDBD35BC3BE89B32021 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ClearanceInstallHelper;
+			packageProductDependencies = (
+			);
+			productName = ClearanceInstallHelper;
+			productReference = 1A7F9312FC0EEDCF296BDA84 /* ClearanceInstallHelper */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -656,6 +720,7 @@
 			targets = (
 				0968501C6A4F63E013A14374 /* Clearance */,
 				4940C8A59120343693655346 /* ClearanceCLI */,
+				9EE20F5D9C219CA6C2119114 /* ClearanceInstallHelper */,
 				38C11196744B99C44D4EF08C /* ClearanceTests */,
 			);
 		};
@@ -712,6 +777,7 @@
 				D0FDE4FA090E278F8A6C0237 /* EditorTemplateTests.swift in Sources */,
 				A25F85DD5F0FCCD6414EA2C6 /* EditorUndoTests.swift in Sources */,
 				6401A4589D5A1F5837D18763 /* FrontmatterParserTests.swift in Sources */,
+				5290372BF856623C18B969F4 /* HelperInstaller.swift in Sources */,
 				A475E28C19B6BBBABA84FB9B /* LocalNavigationPolicyTests.swift in Sources */,
 				6F68BE33AC851E70A98A9724 /* MarkdownLinkRouterTests.swift in Sources */,
 				AB6D8C4C5E85E814711E8D97 /* OutlineSplitViewControllerTests.swift in Sources */,
@@ -771,9 +837,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E5E464F70A828EBB53E7AA83 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				61790119A8642AEF6810AFE5 /* HelperInstaller.swift in Sources */,
+				4534C8089BA37FF80EE2C7BB /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		B6DDED29E1185BD41FB7D3B0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9EE20F5D9C219CA6C2119114 /* ClearanceInstallHelper */;
+			targetProxy = 157644D69837994F2F69E14B /* PBXContainerItemProxy */;
+		};
 		BEA4828002994425BE2876C3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 4940C8A59120343693655346 /* ClearanceCLI */;
@@ -886,6 +966,22 @@
 			};
 			name = Debug;
 		};
+		C22DE2534203C8FF301247CA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.jesse.ClearanceInstallHelper;
+				PRODUCT_NAME = ClearanceInstallHelper;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
 		C5DB764A27DC99BEF676BE8E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -896,6 +992,22 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.jesse.ClearanceCLI;
 				PRODUCT_NAME = clearance;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		EBA68E6E1BFD6109A02C6AB9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.jesse.ClearanceInstallHelper;
+				PRODUCT_NAME = ClearanceInstallHelper;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 6.0;
 			};
@@ -1037,6 +1149,15 @@
 			buildConfigurations = (
 				36D9090D7E04A2E073FC0137 /* Debug */,
 				C5DB764A27DC99BEF676BE8E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		A47438F3F0A9DD6AA39C2F22 /* Build configuration list for PBXNativeTarget "ClearanceInstallHelper" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C22DE2534203C8FF301247CA /* Debug */,
+				EBA68E6E1BFD6109A02C6AB9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/Clearance.xcodeproj/xcshareddata/xcschemes/Clearance.xcscheme
+++ b/Clearance.xcodeproj/xcshareddata/xcschemes/Clearance.xcscheme
@@ -23,6 +23,20 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9EE20F5D9C219CA6C2119114"
+               BuildableName = "ClearanceInstallHelper"
+               BlueprintName = "ClearanceInstallHelper"
+               ReferencedContainer = "container:Clearance.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"

--- a/Clearance/Services/ClearanceCommandLineToolInstaller.swift
+++ b/Clearance/Services/ClearanceCommandLineToolInstaller.swift
@@ -8,7 +8,7 @@ private func _AuthorizationExecuteWithPrivileges(
     _ authorization: AuthorizationRef,
     _ pathToTool: UnsafePointer<CChar>,
     _ options: AuthorizationFlags,
-    _ arguments: UnsafePointer<UnsafeMutablePointer<CChar>>,
+    _ arguments: UnsafePointer<UnsafeMutablePointer<CChar>?>,
     _ communicationsPipe: UnsafeMutablePointer<UnsafeMutablePointer<FILE>?>?
 ) -> OSStatus
 
@@ -85,7 +85,7 @@ struct ClearanceCommandLineToolInstaller {
                 destination.path.withCString { destCStr in
                     var srcPtr = UnsafeMutablePointer(mutating: sourceCStr)
                     var dstPtr = UnsafeMutablePointer(mutating: destCStr)
-                    var args: [UnsafeMutablePointer<CChar>] = [srcPtr, dstPtr]
+                    var args: [UnsafeMutablePointer<CChar>?] = [srcPtr, dstPtr, nil]
                     execStatus = args.withUnsafeMutableBufferPointer { buf in
                         _AuthorizationExecuteWithPrivileges(
                             authRef, helperBinary.path, [], buf.baseAddress!, &pipe

--- a/Clearance/Services/ClearanceCommandLineToolInstaller.swift
+++ b/Clearance/Services/ClearanceCommandLineToolInstaller.swift
@@ -179,11 +179,6 @@ struct ClearanceCommandLineToolInstaller {
         installURL: URL,
         privilegedRunner: PrivilegedRunner
     ) throws {
-        do {
-            try privilegedRunner.run(helperExecutableURL, installURL)
-        } catch ClearanceCommandLineToolInstallerError.privilegedInstallCancelled {
-            return  // Silent no-op — user's intent is clear
-        }
-        // All other errors propagate to the caller
+        try privilegedRunner.run(helperExecutableURL, installURL)
     }
 }

--- a/Clearance/Services/ClearanceCommandLineToolInstaller.swift
+++ b/Clearance/Services/ClearanceCommandLineToolInstaller.swift
@@ -1,32 +1,140 @@
 import Foundation
+import Security
+
+// AuthorizationExecuteWithPrivileges is deprecated and unavailable in Swift.
+// We redeclare it via @_silgen_name to call the underlying C symbol directly.
+@_silgen_name("AuthorizationExecuteWithPrivileges")
+private func _AuthorizationExecuteWithPrivileges(
+    _ authorization: AuthorizationRef,
+    _ pathToTool: UnsafePointer<CChar>,
+    _ options: AuthorizationFlags,
+    _ arguments: UnsafePointer<UnsafeMutablePointer<CChar>>,
+    _ communicationsPipe: UnsafeMutablePointer<UnsafeMutablePointer<FILE>?>?
+) -> OSStatus
 
 enum ClearanceCommandLineToolInstallerError: LocalizedError, Equatable {
     case existingInstallIsNotASymlink(URL)
     case installDirectoryNotWritable(URL)
+    case privilegedInstallCancelled
+    case privilegedInstallFailed(String)
 
     var errorDescription: String? {
         switch self {
         case .existingInstallIsNotASymlink(let url):
             return "\(url.path) already exists and is not a symlink."
         case .installDirectoryNotWritable(let url):
-            return "\(url.path) is not writable for your user. Install `clearance` there with admin privileges, or create the symlink in another directory on your PATH."
+            return "\(url.path) is not writable. Could not obtain admin privileges."
+        case .privilegedInstallCancelled:
+            return nil
+        case .privilegedInstallFailed(let message):
+            return message
         }
     }
 }
 
 struct ClearanceCommandLineToolInstaller {
+    struct PrivilegedRunner: @unchecked Sendable {
+        var run: (_ source: URL, _ destination: URL) throws -> Void
+
+        init(_ run: @escaping (_ source: URL, _ destination: URL) throws -> Void) {
+            self.run = run
+        }
+
+        static let live = PrivilegedRunner { source, destination in
+            guard let helperBinary = Bundle.main.url(
+                forAuxiliaryExecutable: "ClearanceInstallHelper"
+            ) else {
+                throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed(
+                    "ClearanceInstallHelper not found in app bundle."
+                )
+            }
+            var authRef: AuthorizationRef?
+            let createStatus = AuthorizationCreate(nil, nil, [], &authRef)
+            guard createStatus == errSecSuccess, let authRef else {
+                throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed(
+                    "Authorization failed (\(createStatus))."
+                )
+            }
+            defer { AuthorizationFree(authRef, [.destroyRights]) }
+
+            var copyStatus: OSStatus = errSecSuccess
+            "system.privilege.admin".withCString { nameCStr in
+                var item = AuthorizationItem(name: nameCStr, valueLength: 0, value: nil, flags: 0)
+                withUnsafeMutablePointer(to: &item) { itemPtr in
+                    var rights = AuthorizationRights(count: 1, items: itemPtr)
+                    copyStatus = AuthorizationCopyRights(
+                        authRef, &rights, nil,
+                        [.interactionAllowed, .extendRights, .preAuthorize],
+                        nil
+                    )
+                }
+            }
+
+            if copyStatus == errAuthorizationCanceled {
+                throw ClearanceCommandLineToolInstallerError.privilegedInstallCancelled
+            }
+            guard copyStatus == errSecSuccess else {
+                throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed(
+                    "Authorization failed (\(copyStatus))."
+                )
+            }
+
+            var pipe: UnsafeMutablePointer<FILE>? = nil
+            var execStatus: OSStatus = errSecSuccess
+            source.path.withCString { sourceCStr in
+                destination.path.withCString { destCStr in
+                    var srcPtr = UnsafeMutablePointer(mutating: sourceCStr)
+                    var dstPtr = UnsafeMutablePointer(mutating: destCStr)
+                    var args: [UnsafeMutablePointer<CChar>] = [srcPtr, dstPtr]
+                    execStatus = args.withUnsafeMutableBufferPointer { buf in
+                        _AuthorizationExecuteWithPrivileges(
+                            authRef, helperBinary.path, [], buf.baseAddress!, &pipe
+                        )
+                    }
+                }
+            }
+
+            guard execStatus == errSecSuccess else {
+                throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed(
+                    "Could not launch installer (\(execStatus))."
+                )
+            }
+
+            var output = ""
+            if let pipe {
+                var buffer = [CChar](repeating: 0, count: 512)
+                while fgets(&buffer, Int32(buffer.count), pipe) != nil {
+                    output += String(cString: buffer)
+                }
+                fclose(pipe)
+            }
+
+            let message = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !message.isEmpty {
+                throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed(message)
+            }
+        }
+    }
+
     static let installURL = URL(fileURLWithPath: "/usr/local/bin/clearance")
 
     static func install(
         helperExecutableURL: URL,
         at installURL: URL = installURL,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        privilegedRunner: PrivilegedRunner = .live
     ) throws {
         let installDirectoryURL = installURL.deletingLastPathComponent()
+        let directoryExists = fileManager.fileExists(atPath: installDirectoryURL.path)
+        let directoryWritable = fileManager.isWritableFile(atPath: installDirectoryURL.path)
 
-        if fileManager.fileExists(atPath: installDirectoryURL.path),
-           !fileManager.isWritableFile(atPath: installDirectoryURL.path) {
-            throw ClearanceCommandLineToolInstallerError.installDirectoryNotWritable(installDirectoryURL)
+        if directoryExists && !directoryWritable {
+            try installWithPrivileges(
+                helperExecutableURL: helperExecutableURL,
+                installURL: installURL,
+                privilegedRunner: privilegedRunner
+            )
+            return
         }
 
         do {
@@ -34,8 +142,15 @@ struct ClearanceCommandLineToolInstaller {
                 at: installDirectoryURL,
                 withIntermediateDirectories: true
             )
-        } catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileWriteNoPermissionError {
-            throw ClearanceCommandLineToolInstallerError.installDirectoryNotWritable(installDirectoryURL)
+        } catch let error as NSError
+            where error.domain == NSCocoaErrorDomain && error.code == NSFileWriteNoPermissionError
+        {
+            try installWithPrivileges(
+                helperExecutableURL: helperExecutableURL,
+                installURL: installURL,
+                privilegedRunner: privilegedRunner
+            )
+            return
         }
 
         if (try? fileManager.destinationOfSymbolicLink(atPath: installURL.path)) != nil {
@@ -45,12 +160,28 @@ struct ClearanceCommandLineToolInstaller {
         }
 
         do {
-            try fileManager.createSymbolicLink(
-                at: installURL,
-                withDestinationURL: helperExecutableURL
+            try fileManager.createSymbolicLink(at: installURL, withDestinationURL: helperExecutableURL)
+        } catch let error as NSError
+            where error.domain == NSCocoaErrorDomain && error.code == NSFileWriteNoPermissionError
+        {
+            try installWithPrivileges(
+                helperExecutableURL: helperExecutableURL,
+                installURL: installURL,
+                privilegedRunner: privilegedRunner
             )
-        } catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileWriteNoPermissionError {
-            throw ClearanceCommandLineToolInstallerError.installDirectoryNotWritable(installDirectoryURL)
         }
+    }
+
+    private static func installWithPrivileges(
+        helperExecutableURL: URL,
+        installURL: URL,
+        privilegedRunner: PrivilegedRunner
+    ) throws {
+        do {
+            try privilegedRunner.run(helperExecutableURL, installURL)
+        } catch ClearanceCommandLineToolInstallerError.privilegedInstallCancelled {
+            return  // Silent no-op — user's intent is clear
+        }
+        // All other errors propagate to the caller
     }
 }

--- a/Clearance/Services/ClearanceCommandLineToolInstaller.swift
+++ b/Clearance/Services/ClearanceCommandLineToolInstaller.swift
@@ -41,9 +41,11 @@ struct ClearanceCommandLineToolInstaller {
         }
 
         static let live = PrivilegedRunner { source, destination in
-            guard let helperBinary = Bundle.main.url(
-                forAuxiliaryExecutable: "ClearanceInstallHelper"
-            ) else {
+            let helperBinary = Bundle.main.bundleURL
+                .appending(path: "Contents", directoryHint: .isDirectory)
+                .appending(path: "Helpers", directoryHint: .isDirectory)
+                .appending(path: "ClearanceInstallHelper")
+            guard FileManager.default.fileExists(atPath: helperBinary.path) else {
                 throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed(
                     "ClearanceInstallHelper not found in app bundle."
                 )

--- a/Clearance/Views/SettingsView.swift
+++ b/Clearance/Views/SettingsView.swift
@@ -71,6 +71,9 @@ struct SettingsView: View {
             try ClearanceCommandLineToolInstaller.install(helperExecutableURL: helperExecutableURL)
             commandLineToolStatus = "Installed `clearance` at \(ClearanceCommandLineToolInstaller.installURL.path)."
             commandLineToolStatusIsError = false
+        } catch ClearanceCommandLineToolInstallerError.privilegedInstallCancelled {
+            commandLineToolStatus = nil
+            commandLineToolStatusIsError = false
         } catch {
             commandLineToolStatus = error.localizedDescription
             commandLineToolStatusIsError = true

--- a/ClearanceInstallHelper/HelperInstaller.swift
+++ b/ClearanceInstallHelper/HelperInstaller.swift
@@ -37,6 +37,7 @@ enum HelperInstaller {
             helperExecutablePath: helperExecutablePath,
             teamIDExtractor: teamIDExtractor
         )
+        try createSymlink(source: source, destination: destination)
     }
 
     static func validateDestination(_ url: URL) throws {
@@ -77,7 +78,15 @@ enum HelperInstaller {
     }
 
     static func createSymlink(source: URL, destination: URL) throws {
-        // TODO
+        let fm = FileManager.default
+        if (try? fm.destinationOfSymbolicLink(atPath: destination.path)) != nil {
+            try fm.removeItem(at: destination)
+        }
+        do {
+            try fm.createSymbolicLink(at: destination, withDestinationURL: source)
+        } catch {
+            throw HelperInstallerError.installFailed(error.localizedDescription)
+        }
     }
 
     static func teamID(forURL url: URL) -> String? {

--- a/ClearanceInstallHelper/HelperInstaller.swift
+++ b/ClearanceInstallHelper/HelperInstaller.swift
@@ -32,6 +32,11 @@ enum HelperInstaller {
     ) throws {
         try validateDestination(destination)
         try validateSource(source, helperExecutablePath: helperExecutablePath)
+        try validateTeamID(
+            source: source,
+            helperExecutablePath: helperExecutablePath,
+            teamIDExtractor: teamIDExtractor
+        )
     }
 
     static func validateDestination(_ url: URL) throws {
@@ -59,7 +64,16 @@ enum HelperInstaller {
         helperExecutablePath: String,
         teamIDExtractor: TeamIDExtractor
     ) throws {
-        // TODO
+        let helperURL = URL(fileURLWithPath: helperExecutablePath)
+        let helperTeamID = teamIDExtractor(helperURL)
+        let sourceTeamID = teamIDExtractor(source)
+
+        // Both unsigned — allow through. If either is signed, they must match.
+        if helperTeamID != nil || sourceTeamID != nil {
+            guard helperTeamID == sourceTeamID else {
+                throw HelperInstallerError.teamIDMismatch
+            }
+        }
     }
 
     static func createSymlink(source: URL, destination: URL) throws {
@@ -67,7 +81,16 @@ enum HelperInstaller {
     }
 
     static func teamID(forURL url: URL) -> String? {
-        // TODO
-        return nil
+        var staticCode: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(url as CFURL, [], &staticCode) == errSecSuccess,
+              let staticCode else { return nil }
+        var info: CFDictionary?
+        guard SecCodeCopySigningInformation(
+            staticCode,
+            SecCSFlags(rawValue: kSecCSSigningInformation),
+            &info
+        ) == errSecSuccess,
+              let dict = info as? [String: Any] else { return nil }
+        return dict[kSecCodeInfoTeamIdentifier as String] as? String
     }
 }

--- a/ClearanceInstallHelper/HelperInstaller.swift
+++ b/ClearanceInstallHelper/HelperInstaller.swift
@@ -1,0 +1,1 @@
+// HelperInstaller.swift — implementation added in next task

--- a/ClearanceInstallHelper/HelperInstaller.swift
+++ b/ClearanceInstallHelper/HelperInstaller.swift
@@ -69,7 +69,7 @@ enum HelperInstaller {
         let helperTeamID = teamIDExtractor(helperURL)
         let sourceTeamID = teamIDExtractor(source)
 
-        // Both unsigned — allow through. If either is signed, they must match.
+        // Both unsigned — allow through. If at least one is signed, both must be signed by the same team.
         if helperTeamID != nil || sourceTeamID != nil {
             guard helperTeamID == sourceTeamID else {
                 throw HelperInstallerError.teamIDMismatch
@@ -81,6 +81,8 @@ enum HelperInstaller {
         let fm = FileManager.default
         if (try? fm.destinationOfSymbolicLink(atPath: destination.path)) != nil {
             try fm.removeItem(at: destination)
+        } else if fm.fileExists(atPath: destination.path) {
+            throw HelperInstallerError.installFailed("Destination already exists and is not a symlink.")
         }
         do {
             try fm.createSymbolicLink(at: destination, withDestinationURL: source)

--- a/ClearanceInstallHelper/HelperInstaller.swift
+++ b/ClearanceInstallHelper/HelperInstaller.swift
@@ -1,1 +1,62 @@
-// HelperInstaller.swift — implementation added in next task
+import Foundation
+import Security
+
+enum HelperInstallerError: LocalizedError, Equatable {
+    case invalidDestination
+    case sourceOutsideBundle
+    case teamIDMismatch
+    case installFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidDestination:
+            return "Destination must be /usr/local/bin/clearance."
+        case .sourceOutsideBundle:
+            return "Source binary is not inside the app bundle."
+        case .teamIDMismatch:
+            return "Source binary is not signed by the same developer as this helper."
+        case .installFailed(let message):
+            return message
+        }
+    }
+}
+
+enum HelperInstaller {
+    typealias TeamIDExtractor = (URL) -> String?
+
+    static func install(
+        source: URL,
+        destination: URL,
+        helperExecutablePath: String = CommandLine.arguments[0],
+        teamIDExtractor: TeamIDExtractor = HelperInstaller.teamID(forURL:)
+    ) throws {
+        try validateDestination(destination)
+    }
+
+    static func validateDestination(_ url: URL) throws {
+        guard url.path == "/usr/local/bin/clearance" else {
+            throw HelperInstallerError.invalidDestination
+        }
+    }
+
+    static func validateSource(_ source: URL, helperExecutablePath: String) throws {
+        // TODO
+    }
+
+    static func validateTeamID(
+        source: URL,
+        helperExecutablePath: String,
+        teamIDExtractor: TeamIDExtractor
+    ) throws {
+        // TODO
+    }
+
+    static func createSymlink(source: URL, destination: URL) throws {
+        // TODO
+    }
+
+    static func teamID(forURL url: URL) -> String? {
+        // TODO
+        return nil
+    }
+}

--- a/ClearanceInstallHelper/HelperInstaller.swift
+++ b/ClearanceInstallHelper/HelperInstaller.swift
@@ -31,6 +31,7 @@ enum HelperInstaller {
         teamIDExtractor: TeamIDExtractor = HelperInstaller.teamID(forURL:)
     ) throws {
         try validateDestination(destination)
+        try validateSource(source, helperExecutablePath: helperExecutablePath)
     }
 
     static func validateDestination(_ url: URL) throws {
@@ -40,7 +41,17 @@ enum HelperInstaller {
     }
 
     static func validateSource(_ source: URL, helperExecutablePath: String) throws {
-        // TODO
+        let helperURL = URL(fileURLWithPath: helperExecutablePath)
+        let bundleRoot = helperURL
+            .deletingLastPathComponent() // Helpers
+            .deletingLastPathComponent() // Contents
+            .deletingLastPathComponent() // bundle root
+
+        let bundlePrefix = bundleRoot.path + "/"
+        guard source.path.hasPrefix(bundlePrefix),
+              FileManager.default.isReadableFile(atPath: source.path) else {
+            throw HelperInstallerError.sourceOutsideBundle
+        }
     }
 
     static func validateTeamID(

--- a/ClearanceInstallHelper/main.swift
+++ b/ClearanceInstallHelper/main.swift
@@ -1,1 +1,18 @@
-// Entry point — implementation added in a later task
+// ClearanceInstallHelper/main.swift
+import Foundation
+
+guard CommandLine.arguments.count == 3 else {
+    print("Usage: ClearanceInstallHelper <source> <destination>")
+    exit(1)
+}
+
+let source = URL(fileURLWithPath: CommandLine.arguments[1])
+let destination = URL(fileURLWithPath: CommandLine.arguments[2])
+
+do {
+    try HelperInstaller.install(source: source, destination: destination)
+    // Empty stdout on success — the app reads empty pipe as success
+} catch {
+    print(error.localizedDescription)
+    exit(1)
+}

--- a/ClearanceInstallHelper/main.swift
+++ b/ClearanceInstallHelper/main.swift
@@ -1,0 +1,1 @@
+// Entry point — implementation added in a later task

--- a/ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift
+++ b/ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift
@@ -59,7 +59,7 @@ final class ClearanceCommandLineInstallerTests: XCTestCase {
         XCTAssertTrue(privilegedRunnerCalled)
     }
 
-    func testPrivilegedInstallCancellationIsSilent() throws {
+    func testPrivilegedInstallCancellationPropagates() throws {
         let helperURL = try makeExecutable(named: "clearance")
         let installDirectoryURL = try makeNonWritableDirectory()
         let installURL = installDirectoryURL.appending(path: "clearance")
@@ -68,13 +68,18 @@ final class ClearanceCommandLineInstallerTests: XCTestCase {
             throw ClearanceCommandLineToolInstallerError.privilegedInstallCancelled
         }
 
-        XCTAssertNoThrow(
+        XCTAssertThrowsError(
             try ClearanceCommandLineToolInstaller.install(
                 helperExecutableURL: helperURL,
                 at: installURL,
                 privilegedRunner: cancellingRunner
             )
-        )
+        ) { error in
+            XCTAssertEqual(
+                error as? ClearanceCommandLineToolInstallerError,
+                .privilegedInstallCancelled
+            )
+        }
     }
 
     func testPrivilegedInstallSurfacesHelperError() throws {

--- a/ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift
+++ b/ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift
@@ -40,25 +40,6 @@ final class ClearanceCommandLineInstallerTests: XCTestCase {
         }
     }
 
-    func testInstallReportsNonWritableInstallDirectory() throws {
-        let helperURL = try makeExecutable(named: "clearance")
-        let installDirectoryURL = try makeNonWritableDirectory()
-        let installURL = installDirectoryURL.appending(path: "clearance")
-
-        var privilegedRunnerCalled = false
-        let runner = ClearanceCommandLineToolInstaller.PrivilegedRunner { _, _ in
-            privilegedRunnerCalled = true
-        }
-
-        try ClearanceCommandLineToolInstaller.install(
-            helperExecutableURL: helperURL,
-            at: installURL,
-            privilegedRunner: runner
-        )
-
-        XCTAssertTrue(privilegedRunnerCalled)
-    }
-
     func testPrivilegedInstallIsAttemptedWhenDirectoryNotWritable() throws {
         let helperURL = try makeExecutable(named: "clearance")
         let installDirectoryURL = try makeNonWritableDirectory()

--- a/ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift
+++ b/ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift
@@ -42,21 +42,79 @@ final class ClearanceCommandLineInstallerTests: XCTestCase {
 
     func testInstallReportsNonWritableInstallDirectory() throws {
         let helperURL = try makeExecutable(named: "clearance")
-        let installDirectoryURL = try makeDirectory().appending(path: "bin", directoryHint: .isDirectory)
+        let installDirectoryURL = try makeNonWritableDirectory()
         let installURL = installDirectoryURL.appending(path: "clearance")
 
-        try FileManager.default.createDirectory(at: installDirectoryURL, withIntermediateDirectories: true)
-        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: installDirectoryURL.path)
-        defer {
-            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: installDirectoryURL.path)
+        var privilegedRunnerCalled = false
+        let runner = ClearanceCommandLineToolInstaller.PrivilegedRunner { _, _ in
+            privilegedRunnerCalled = true
+        }
+
+        try ClearanceCommandLineToolInstaller.install(
+            helperExecutableURL: helperURL,
+            at: installURL,
+            privilegedRunner: runner
+        )
+
+        XCTAssertTrue(privilegedRunnerCalled)
+    }
+
+    func testPrivilegedInstallIsAttemptedWhenDirectoryNotWritable() throws {
+        let helperURL = try makeExecutable(named: "clearance")
+        let installDirectoryURL = try makeNonWritableDirectory()
+        let installURL = installDirectoryURL.appending(path: "clearance")
+
+        var privilegedRunnerCalled = false
+        let runner = ClearanceCommandLineToolInstaller.PrivilegedRunner { _, _ in
+            privilegedRunnerCalled = true
+        }
+
+        try ClearanceCommandLineToolInstaller.install(
+            helperExecutableURL: helperURL,
+            at: installURL,
+            privilegedRunner: runner
+        )
+
+        XCTAssertTrue(privilegedRunnerCalled)
+    }
+
+    func testPrivilegedInstallCancellationIsSilent() throws {
+        let helperURL = try makeExecutable(named: "clearance")
+        let installDirectoryURL = try makeNonWritableDirectory()
+        let installURL = installDirectoryURL.appending(path: "clearance")
+
+        let cancellingRunner = ClearanceCommandLineToolInstaller.PrivilegedRunner { _, _ in
+            throw ClearanceCommandLineToolInstallerError.privilegedInstallCancelled
+        }
+
+        XCTAssertNoThrow(
+            try ClearanceCommandLineToolInstaller.install(
+                helperExecutableURL: helperURL,
+                at: installURL,
+                privilegedRunner: cancellingRunner
+            )
+        )
+    }
+
+    func testPrivilegedInstallSurfacesHelperError() throws {
+        let helperURL = try makeExecutable(named: "clearance")
+        let installDirectoryURL = try makeNonWritableDirectory()
+        let installURL = installDirectoryURL.appending(path: "clearance")
+
+        let failingRunner = ClearanceCommandLineToolInstaller.PrivilegedRunner { _, _ in
+            throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed("helper said no")
         }
 
         XCTAssertThrowsError(
-            try ClearanceCommandLineToolInstaller.install(helperExecutableURL: helperURL, at: installURL)
+            try ClearanceCommandLineToolInstaller.install(
+                helperExecutableURL: helperURL,
+                at: installURL,
+                privilegedRunner: failingRunner
+            )
         ) { error in
             XCTAssertEqual(
                 error as? ClearanceCommandLineToolInstallerError,
-                .installDirectoryNotWritable(installDirectoryURL)
+                .privilegedInstallFailed("helper said no")
             )
         }
     }
@@ -71,6 +129,16 @@ final class ClearanceCommandLineInstallerTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makeNonWritableDirectory() throws -> URL {
+        let url = try makeDirectory().appending(path: "bin", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: url.path)
+        addTeardownBlock {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        }
         return url
     }
 }

--- a/ClearanceTests/Services/ClearanceInstallHelperTests.swift
+++ b/ClearanceTests/Services/ClearanceInstallHelperTests.swift
@@ -99,6 +99,17 @@ final class ClearanceInstallHelperTests: XCTestCase {
         )
     }
 
+    func testCreateSymlinkRefusesToReplaceExistingRegularFile() throws {
+        let (source, _, destination) = try makeBundleFixture()
+        try Data().write(to: destination)
+
+        XCTAssertThrowsError(
+            try HelperInstaller.createSymlink(source: source, destination: destination)
+        ) { error in
+            XCTAssertEqual(error as? HelperInstallerError, .installFailed("Destination already exists and is not a symlink."))
+        }
+    }
+
     func testCreateSymlinkReplacesExistingSymlink() throws {
         let (source, _, destination) = try makeBundleFixture()
         let oldTarget = try makeFile(named: "old-clearance")
@@ -125,7 +136,7 @@ final class ClearanceInstallHelperTests: XCTestCase {
 
     /// Creates a fake bundle at /tmp/<uuid>/fake.app with a clearance binary inside.
     /// Returns (sourceURL, helperExecutablePath, writableDestinationURL).
-    func makeBundleFixture() throws -> (source: URL, helperPath: String, destination: URL) {
+    private func makeBundleFixture() throws -> (source: URL, helperPath: String, destination: URL) {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
         let helpersDir = dir.appendingPathComponent("fake.app/Contents/Helpers")

--- a/ClearanceTests/Services/ClearanceInstallHelperTests.swift
+++ b/ClearanceTests/Services/ClearanceInstallHelperTests.swift
@@ -86,6 +86,32 @@ final class ClearanceInstallHelperTests: XCTestCase {
         )
     }
 
+    // MARK: - Symlink creation
+
+    func testCreateSymlinkCreatesSymlink() throws {
+        let (source, _, destination) = try makeBundleFixture()
+
+        try HelperInstaller.createSymlink(source: source, destination: destination)
+
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: destination.path),
+            source.path
+        )
+    }
+
+    func testCreateSymlinkReplacesExistingSymlink() throws {
+        let (source, _, destination) = try makeBundleFixture()
+        let oldTarget = try makeFile(named: "old-clearance")
+        try FileManager.default.createSymbolicLink(at: destination, withDestinationURL: oldTarget)
+
+        try HelperInstaller.createSymlink(source: source, destination: destination)
+
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: destination.path),
+            source.path
+        )
+    }
+
     // MARK: - Helpers (used by later tasks too)
 
     private func makeFile(named name: String, in dir: URL? = nil) throws -> URL {

--- a/ClearanceTests/Services/ClearanceInstallHelperTests.swift
+++ b/ClearanceTests/Services/ClearanceInstallHelperTests.swift
@@ -44,6 +44,48 @@ final class ClearanceInstallHelperTests: XCTestCase {
         )
     }
 
+    // MARK: - Team ID verification
+
+    func testValidateTeamIDRejectsMismatch() throws {
+        let (source, helperPath, _) = try makeBundleFixture()
+
+        XCTAssertThrowsError(
+            try HelperInstaller.validateTeamID(
+                source: source,
+                helperExecutablePath: helperPath,
+                teamIDExtractor: { url in
+                    url.lastPathComponent == "clearance" ? "AAAAAA" : "BBBBBB"
+                }
+            )
+        ) { error in
+            XCTAssertEqual(error as? HelperInstallerError, .teamIDMismatch)
+        }
+    }
+
+    func testValidateTeamIDAcceptsMatchingTeamIDs() throws {
+        let (source, helperPath, _) = try makeBundleFixture()
+
+        XCTAssertNoThrow(
+            try HelperInstaller.validateTeamID(
+                source: source,
+                helperExecutablePath: helperPath,
+                teamIDExtractor: { _ in "SAMETEAM" }
+            )
+        )
+    }
+
+    func testValidateTeamIDAllowsBothUnsigned() throws {
+        let (source, helperPath, _) = try makeBundleFixture()
+
+        XCTAssertNoThrow(
+            try HelperInstaller.validateTeamID(
+                source: source,
+                helperExecutablePath: helperPath,
+                teamIDExtractor: { _ in nil }
+            )
+        )
+    }
+
     // MARK: - Helpers (used by later tasks too)
 
     private func makeFile(named name: String, in dir: URL? = nil) throws -> URL {

--- a/ClearanceTests/Services/ClearanceInstallHelperTests.swift
+++ b/ClearanceTests/Services/ClearanceInstallHelperTests.swift
@@ -1,0 +1,51 @@
+// Note: no import needed for HelperInstaller — it is compiled directly into this target.
+import XCTest
+@testable import Clearance
+
+final class ClearanceInstallHelperTests: XCTestCase {
+
+    // MARK: - Destination validation
+
+    func testValidateDestinationRejectsInvalidPath() throws {
+        XCTAssertThrowsError(
+            try HelperInstaller.validateDestination(URL(fileURLWithPath: "/usr/local/bin/other"))
+        ) { error in
+            XCTAssertEqual(error as? HelperInstallerError, .invalidDestination)
+        }
+    }
+
+    func testValidateDestinationAcceptsCorrectPath() {
+        XCTAssertNoThrow(
+            try HelperInstaller.validateDestination(
+                URL(fileURLWithPath: "/usr/local/bin/clearance")
+            )
+        )
+    }
+
+    // MARK: - Helpers (used by later tasks too)
+
+    private func makeFile(named name: String, in dir: URL? = nil) throws -> URL {
+        let directory = dir ?? FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent(name)
+        try Data().write(to: url)
+        return url
+    }
+
+    /// Creates a fake bundle at /tmp/<uuid>/fake.app with a clearance binary inside.
+    /// Returns (sourceURL, helperExecutablePath, writableDestinationURL).
+    func makeBundleFixture() throws -> (source: URL, helperPath: String, destination: URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        let helpersDir = dir.appendingPathComponent("fake.app/Contents/Helpers")
+        try FileManager.default.createDirectory(at: helpersDir, withIntermediateDirectories: true)
+        let source = helpersDir.appendingPathComponent("clearance")
+        try Data().write(to: source)
+        let helperPath = helpersDir.appendingPathComponent("ClearanceInstallHelper").path
+        let binDir = dir.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        let destination = binDir.appendingPathComponent("clearance")
+        return (source, helperPath, destination)
+    }
+}

--- a/ClearanceTests/Services/ClearanceInstallHelperTests.swift
+++ b/ClearanceTests/Services/ClearanceInstallHelperTests.swift
@@ -22,6 +22,28 @@ final class ClearanceInstallHelperTests: XCTestCase {
         )
     }
 
+    // MARK: - Source validation
+
+    func testValidateSourceRejectsPathOutsideBundle() throws {
+        let (_, helperPath, _) = try makeBundleFixture()
+        // This source is in a completely different temp directory — not inside the bundle
+        let outsideSource = try makeFile(named: "clearance")
+
+        XCTAssertThrowsError(
+            try HelperInstaller.validateSource(outsideSource, helperExecutablePath: helperPath)
+        ) { error in
+            XCTAssertEqual(error as? HelperInstallerError, .sourceOutsideBundle)
+        }
+    }
+
+    func testValidateSourceAcceptsPathInsideBundle() throws {
+        let (source, helperPath, _) = try makeBundleFixture()
+
+        XCTAssertNoThrow(
+            try HelperInstaller.validateSource(source, helperExecutablePath: helperPath)
+        )
+    }
+
     // MARK: - Helpers (used by later tasks too)
 
     private func makeFile(named name: String, in dir: URL? = nil) throws -> URL {

--- a/docs/superpowers/plans/2026-03-20-privileged-cli-installer.md
+++ b/docs/superpowers/plans/2026-03-20-privileged-cli-installer.md
@@ -1,0 +1,957 @@
+# Privileged CLI Installer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When `/usr/local/bin` is not writable, prompt the user for their admin password and create the `clearance` symlink using a privileged helper binary.
+
+**Architecture:** A new `ClearanceInstallHelper` tool target contains all privileged logic. The main app uses Authorization Services to show an inline auth dialog, then spawns the helper as root via `AuthorizationExecuteWithPrivileges`. The helper validates arguments, verifies code signing Team IDs, and creates the symlink. Success/failure is communicated through stdout (empty = success, message = failure).
+
+**Tech Stack:** Swift 6.0, Foundation, Security framework, Authorization Services (`AuthorizationCreate`, `AuthorizationCopyRights`, `AuthorizationExecuteWithPrivileges`)
+
+**Spec:** `docs/superpowers/specs/2026-03-20-privileged-cli-installer-design.md`
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `ClearanceInstallHelper/main.swift` | CLI entry point: parse args, call `HelperInstaller`, write errors to stdout |
+| Create | `ClearanceInstallHelper/HelperInstaller.swift` | Core logic: validate args, verify Team IDs, create symlink. Compiled directly into the test target too. |
+| Create | `ClearanceTests/Services/ClearanceInstallHelperTests.swift` | Unit tests for `HelperInstaller` |
+| Modify | `project.yml` | Add `ClearanceInstallHelper` target; add `HelperInstaller.swift` as an explicit source for `ClearanceTests` |
+| Modify | `Clearance/Services/ClearanceCommandLineToolInstaller.swift` | Add `PrivilegedRunner` type and privileged fallback |
+| Modify | `ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift` | Add tests for privileged path error mapping |
+
+**Note on `HelperInstaller` test access:** `HelperInstaller.swift` is listed as a direct source file for the `ClearanceTests` target in `project.yml` — it is compiled straight into the test bundle. No `import` statement is needed to use `HelperInstaller` in tests; it is simply in scope. The `@testable import Clearance` in the test file imports the main app module for other types; `HelperInstaller` and `HelperInstallerError` are available without any import.
+
+---
+
+## Task 1: Add `ClearanceInstallHelper` target to project.yml
+
+**Files:**
+- Modify: `project.yml`
+
+- [ ] **Step 1: Add the target**
+
+In `project.yml`, add after the `ClearanceCLI` target block and before `ClearanceTests`:
+
+```yaml
+  ClearanceInstallHelper:
+    type: tool
+    platform: macOS
+    sources:
+      - path: ClearanceInstallHelper
+    settings:
+      base:
+        PRODUCT_NAME: ClearanceInstallHelper
+        SWIFT_VERSION: 6.0
+        ENABLE_HARDENED_RUNTIME: YES
+    dependencies:
+      - sdk: Security.framework
+```
+
+In the `Clearance` target's `dependencies`, add after the `ClearanceCLI` embed block:
+
+```yaml
+      - target: ClearanceInstallHelper
+        link: false
+        embed: true
+        copy:
+          destination: wrapper
+          subpath: Contents/Helpers
+```
+
+In the `ClearanceTests` target, change `sources` to include the shared logic file:
+
+```yaml
+    sources:
+      - path: ClearanceTests
+      - path: ClearanceInstallHelper/HelperInstaller.swift
+```
+
+- [ ] **Step 2: Create the source directory and regenerate the project**
+
+```bash
+mkdir -p ClearanceInstallHelper
+xcodegen generate
+```
+
+Expected: `Created project at /path/to/Clearance.xcodeproj`
+
+- [ ] **Step 3: Verify the build succeeds**
+
+```bash
+xcodebuild build -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' 2>&1 | grep -E "(BUILD|error:)"
+```
+
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add project.yml Clearance.xcodeproj/project.pbxproj
+git commit -m "Add ClearanceInstallHelper target to project"
+```
+
+---
+
+## Task 2: `HelperInstaller` — skeleton and destination validation (TDD)
+
+**Files:**
+- Create: `ClearanceInstallHelper/HelperInstaller.swift`
+- Create: `ClearanceTests/Services/ClearanceInstallHelperTests.swift`
+
+- [ ] **Step 1: Create a minimal `HelperInstaller.swift` stub — no implementation yet**
+
+```swift
+// ClearanceInstallHelper/HelperInstaller.swift
+import Foundation
+import Security
+
+enum HelperInstallerError: LocalizedError, Equatable {
+    case invalidDestination
+    case sourceOutsideBundle
+    case teamIDMismatch
+    case installFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidDestination:
+            return "Destination must be /usr/local/bin/clearance."
+        case .sourceOutsideBundle:
+            return "Source binary is not inside the app bundle."
+        case .teamIDMismatch:
+            return "Source binary is not signed by the same developer as this helper."
+        case .installFailed(let message):
+            return message
+        }
+    }
+}
+
+enum HelperInstaller {
+    typealias TeamIDExtractor = (URL) -> String?
+
+    static func install(
+        source: URL,
+        destination: URL,
+        helperExecutablePath: String = CommandLine.arguments[0],
+        teamIDExtractor: TeamIDExtractor = HelperInstaller.teamID(forURL:)
+    ) throws {
+        // TODO
+    }
+
+    static func validateDestination(_ url: URL) throws {
+        // TODO
+    }
+
+    static func validateSource(_ source: URL, helperExecutablePath: String) throws {
+        // TODO
+    }
+
+    static func validateTeamID(
+        source: URL,
+        helperExecutablePath: String,
+        teamIDExtractor: TeamIDExtractor
+    ) throws {
+        // TODO
+    }
+
+    static func createSymlink(source: URL, destination: URL) throws {
+        // TODO
+    }
+
+    static func teamID(forURL url: URL) -> String? {
+        // TODO
+        return nil
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+```swift
+// ClearanceTests/Services/ClearanceInstallHelperTests.swift
+// Note: no import needed for HelperInstaller — it is compiled directly into this target.
+import XCTest
+@testable import Clearance
+
+final class ClearanceInstallHelperTests: XCTestCase {
+
+    // MARK: - Destination validation
+
+    func testValidateDestinationRejectsInvalidPath() throws {
+        XCTAssertThrowsError(
+            try HelperInstaller.validateDestination(URL(fileURLWithPath: "/usr/local/bin/other"))
+        ) { error in
+            XCTAssertEqual(error as? HelperInstallerError, .invalidDestination)
+        }
+    }
+
+    func testValidateDestinationAcceptsCorrectPath() {
+        XCTAssertNoThrow(
+            try HelperInstaller.validateDestination(
+                URL(fileURLWithPath: "/usr/local/bin/clearance")
+            )
+        )
+    }
+
+    // MARK: - Helpers (used by later tasks too)
+
+    private func makeFile(named name: String, in dir: URL? = nil) throws -> URL {
+        let directory = dir ?? FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent(name)
+        try Data().write(to: url)
+        return url
+    }
+
+    /// Creates a fake bundle at /tmp/<uuid>/fake.app with a clearance binary inside.
+    /// Returns (sourceURL, helperExecutablePath, writableDestinationURL).
+    func makeBundleFixture() throws -> (source: URL, helperPath: String, destination: URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        let helpersDir = dir.appendingPathComponent("fake.app/Contents/Helpers")
+        try FileManager.default.createDirectory(at: helpersDir, withIntermediateDirectories: true)
+        let source = helpersDir.appendingPathComponent("clearance")
+        try Data().write(to: source)
+        let helperPath = helpersDir.appendingPathComponent("ClearanceInstallHelper").path
+        let binDir = dir.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        let destination = binDir.appendingPathComponent("clearance")
+        return (source, helperPath, destination)
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to confirm they fail**
+
+```bash
+xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceInstallHelperTests 2>&1 | grep -E "(passed|failed|error:)"
+```
+
+Expected: Both destination tests FAIL (the TODO stubs don't throw or validate anything).
+
+- [ ] **Step 4: Implement `validateDestination`**
+
+```swift
+static func validateDestination(_ url: URL) throws {
+    guard url.path == "/usr/local/bin/clearance" else {
+        throw HelperInstallerError.invalidDestination
+    }
+}
+```
+
+Also wire it into `install`:
+
+```swift
+static func install(
+    source: URL,
+    destination: URL,
+    helperExecutablePath: String = CommandLine.arguments[0],
+    teamIDExtractor: TeamIDExtractor = HelperInstaller.teamID(forURL:)
+) throws {
+    try validateDestination(destination)
+}
+```
+
+- [ ] **Step 5: Run tests to confirm they pass**
+
+```bash
+xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceInstallHelperTests 2>&1 | grep -E "(passed|failed)"
+```
+
+Expected: Both destination tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ClearanceInstallHelper/HelperInstaller.swift ClearanceTests/Services/ClearanceInstallHelperTests.swift
+git commit -m "Add HelperInstaller skeleton and destination validation"
+```
+
+---
+
+## Task 3: `HelperInstaller` — source path validation
+
+**Files:**
+- Modify: `ClearanceInstallHelper/HelperInstaller.swift`
+- Modify: `ClearanceTests/Services/ClearanceInstallHelperTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `ClearanceInstallHelperTests`:
+
+```swift
+// MARK: - Source validation
+
+func testValidateSourceRejectsPathOutsideBundle() throws {
+    let (_, helperPath, _) = try makeBundleFixture()
+    // This source is in a completely different temp directory — not inside the bundle
+    let outsideSource = try makeFile(named: "clearance")
+
+    XCTAssertThrowsError(
+        try HelperInstaller.validateSource(outsideSource, helperExecutablePath: helperPath)
+    ) { error in
+        XCTAssertEqual(error as? HelperInstallerError, .sourceOutsideBundle)
+    }
+}
+
+func testValidateSourceAcceptsPathInsideBundle() throws {
+    let (source, helperPath, _) = try makeBundleFixture()
+
+    XCTAssertNoThrow(
+        try HelperInstaller.validateSource(source, helperExecutablePath: helperPath)
+    )
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceInstallHelperTests/testValidateSourceRejectsPathOutsideBundle 2>&1 | grep -E "(passed|failed)"
+```
+
+Expected: FAILED
+
+- [ ] **Step 3: Implement `validateSource`**
+
+```swift
+static func validateSource(_ source: URL, helperExecutablePath: String) throws {
+    let helperURL = URL(fileURLWithPath: helperExecutablePath)
+    let bundleRoot = helperURL
+        .deletingLastPathComponent() // Helpers
+        .deletingLastPathComponent() // Contents
+        .deletingLastPathComponent() // bundle root
+
+    let bundlePrefix = bundleRoot.path + "/"
+    guard source.path.hasPrefix(bundlePrefix),
+          FileManager.default.isReadableFile(atPath: source.path) else {
+        throw HelperInstallerError.sourceOutsideBundle
+    }
+}
+```
+
+Wire into `install`:
+
+```swift
+static func install(...) throws {
+    try validateDestination(destination)
+    try validateSource(source, helperExecutablePath: helperExecutablePath)
+}
+```
+
+- [ ] **Step 4: Run all helper tests**
+
+```bash
+xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceInstallHelperTests 2>&1 | grep -E "(passed|failed)"
+```
+
+Expected: All passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ClearanceInstallHelper/HelperInstaller.swift ClearanceTests/Services/ClearanceInstallHelperTests.swift
+git commit -m "Add source path validation to HelperInstaller"
+```
+
+---
+
+## Task 4: `HelperInstaller` — Team ID verification
+
+**Files:**
+- Modify: `ClearanceInstallHelper/HelperInstaller.swift`
+- Modify: `ClearanceTests/Services/ClearanceInstallHelperTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `ClearanceInstallHelperTests`. The `teamIDExtractor` is injected so tests don't need real signed binaries:
+
+```swift
+// MARK: - Team ID verification
+
+func testValidateTeamIDRejectsMismatch() throws {
+    let (source, helperPath, _) = try makeBundleFixture()
+
+    XCTAssertThrowsError(
+        try HelperInstaller.validateTeamID(
+            source: source,
+            helperExecutablePath: helperPath,
+            teamIDExtractor: { url in
+                url.lastPathComponent == "clearance" ? "AAAAAA" : "BBBBBB"
+            }
+        )
+    ) { error in
+        XCTAssertEqual(error as? HelperInstallerError, .teamIDMismatch)
+    }
+}
+
+func testValidateTeamIDAcceptsMatchingTeamIDs() throws {
+    let (source, helperPath, _) = try makeBundleFixture()
+
+    XCTAssertNoThrow(
+        try HelperInstaller.validateTeamID(
+            source: source,
+            helperExecutablePath: helperPath,
+            teamIDExtractor: { _ in "SAMETEAM" }
+        )
+    )
+}
+
+func testValidateTeamIDAllowsBothUnsigned() throws {
+    let (source, helperPath, _) = try makeBundleFixture()
+
+    XCTAssertNoThrow(
+        try HelperInstaller.validateTeamID(
+            source: source,
+            helperExecutablePath: helperPath,
+            teamIDExtractor: { _ in nil }
+        )
+    )
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceInstallHelperTests/testValidateTeamIDRejectsMismatch 2>&1 | grep -E "(passed|failed)"
+```
+
+Expected: FAILED
+
+- [ ] **Step 3: Implement `validateTeamID` and `teamID(forURL:)`**
+
+```swift
+static func validateTeamID(
+    source: URL,
+    helperExecutablePath: String,
+    teamIDExtractor: TeamIDExtractor
+) throws {
+    let helperURL = URL(fileURLWithPath: helperExecutablePath)
+    let helperTeamID = teamIDExtractor(helperURL)
+    let sourceTeamID = teamIDExtractor(source)
+
+    // Both unsigned — allow through. If either is signed, they must match.
+    if helperTeamID != nil || sourceTeamID != nil {
+        guard helperTeamID == sourceTeamID else {
+            throw HelperInstallerError.teamIDMismatch
+        }
+    }
+}
+
+static func teamID(forURL url: URL) -> String? {
+    var staticCode: SecStaticCode?
+    guard SecStaticCodeCreateWithPath(url as CFURL, [], &staticCode) == errSecSuccess,
+          let staticCode else { return nil }
+    // SecStaticCode and SecCode share the same CF backing type; unsafeBitCast is
+    // the standard workaround since SecCodeCopySigningInformation requires SecCode.
+    let code = unsafeBitCast(staticCode, to: SecCode.self)
+    var info: CFDictionary?
+    guard SecCodeCopySigningInformation(
+        code,
+        SecCSFlags(rawValue: kSecCSSigningInformation),
+        &info
+    ) == errSecSuccess,
+          let dict = info as? [String: Any] else { return nil }
+    return dict[kSecCodeInfoTeamIdentifier as String] as? String
+}
+```
+
+Wire into `install`:
+
+```swift
+static func install(...) throws {
+    try validateDestination(destination)
+    try validateSource(source, helperExecutablePath: helperExecutablePath)
+    try validateTeamID(
+        source: source,
+        helperExecutablePath: helperExecutablePath,
+        teamIDExtractor: teamIDExtractor
+    )
+}
+```
+
+- [ ] **Step 4: Run all helper tests**
+
+```bash
+xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceInstallHelperTests 2>&1 | grep -E "(passed|failed)"
+```
+
+Expected: All passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ClearanceInstallHelper/HelperInstaller.swift ClearanceTests/Services/ClearanceInstallHelperTests.swift
+git commit -m "Add Team ID verification to HelperInstaller"
+```
+
+---
+
+## Task 5: `HelperInstaller` — symlink creation
+
+**Files:**
+- Modify: `ClearanceInstallHelper/HelperInstaller.swift`
+- Modify: `ClearanceTests/Services/ClearanceInstallHelperTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `ClearanceInstallHelperTests`. These call `createSymlink` directly using the writable temp destination from `makeBundleFixture`:
+
+```swift
+// MARK: - Symlink creation
+
+func testCreateSymlinkCreatesSymlink() throws {
+    let (source, _, destination) = try makeBundleFixture()
+
+    try HelperInstaller.createSymlink(source: source, destination: destination)
+
+    XCTAssertEqual(
+        try FileManager.default.destinationOfSymbolicLink(atPath: destination.path),
+        source.path
+    )
+}
+
+func testCreateSymlinkReplacesExistingSymlink() throws {
+    let (source, _, destination) = try makeBundleFixture()
+    let oldTarget = try makeFile(named: "old-clearance")
+    try FileManager.default.createSymbolicLink(at: destination, withDestinationURL: oldTarget)
+
+    try HelperInstaller.createSymlink(source: source, destination: destination)
+
+    XCTAssertEqual(
+        try FileManager.default.destinationOfSymbolicLink(atPath: destination.path),
+        source.path
+    )
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceInstallHelperTests/testCreateSymlinkCreatesSymlink 2>&1 | grep -E "(passed|failed)"
+```
+
+Expected: FAILED
+
+- [ ] **Step 3: Implement `createSymlink`**
+
+```swift
+static func createSymlink(source: URL, destination: URL) throws {
+    let fm = FileManager.default
+    if (try? fm.destinationOfSymbolicLink(atPath: destination.path)) != nil {
+        try fm.removeItem(at: destination)
+    }
+    do {
+        try fm.createSymbolicLink(at: destination, withDestinationURL: source)
+    } catch {
+        throw HelperInstallerError.installFailed(error.localizedDescription)
+    }
+}
+```
+
+Wire into `install`:
+
+```swift
+static func install(...) throws {
+    try validateDestination(destination)
+    try validateSource(source, helperExecutablePath: helperExecutablePath)
+    try validateTeamID(
+        source: source,
+        helperExecutablePath: helperExecutablePath,
+        teamIDExtractor: teamIDExtractor
+    )
+    try createSymlink(source: source, destination: destination)
+}
+```
+
+- [ ] **Step 4: Run all helper tests**
+
+```bash
+xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceInstallHelperTests 2>&1 | grep -E "(passed|failed)"
+```
+
+Expected: All passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ClearanceInstallHelper/HelperInstaller.swift ClearanceTests/Services/ClearanceInstallHelperTests.swift
+git commit -m "Add symlink creation to HelperInstaller"
+```
+
+---
+
+## Task 6: `main.swift` — entry point
+
+**Files:**
+- Create: `ClearanceInstallHelper/main.swift`
+
+- [ ] **Step 1: Write `main.swift`**
+
+```swift
+// ClearanceInstallHelper/main.swift
+import Foundation
+
+guard CommandLine.arguments.count == 3 else {
+    print("Usage: ClearanceInstallHelper <source> <destination>")
+    exit(1)
+}
+
+let source = URL(fileURLWithPath: CommandLine.arguments[1])
+let destination = URL(fileURLWithPath: CommandLine.arguments[2])
+
+do {
+    try HelperInstaller.install(source: source, destination: destination)
+    // Empty stdout on success — the app reads empty pipe as success
+} catch {
+    print(error.localizedDescription)
+    exit(1)
+}
+```
+
+- [ ] **Step 2: Verify the project builds**
+
+```bash
+xcodebuild build -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' 2>&1 | grep -E "(BUILD|error:)"
+```
+
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ClearanceInstallHelper/main.swift
+git commit -m "Add ClearanceInstallHelper entry point"
+```
+
+---
+
+## Task 7: `ClearanceCommandLineToolInstaller` — privileged fallback
+
+**Files:**
+- Modify: `Clearance/Services/ClearanceCommandLineToolInstaller.swift`
+- Modify: `ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift`
+
+**Note:** `makeDirectory()` already exists in `ClearanceCommandLineInstallerTests`. The new `makeNonWritableDirectory()` helper added below calls it.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `ClearanceCommandLineInstallerTests`:
+
+```swift
+func testPrivilegedInstallIsAttemptedWhenDirectoryNotWritable() throws {
+    let helperURL = try makeExecutable(named: "clearance")
+    let installDirectoryURL = try makeNonWritableDirectory()
+    let installURL = installDirectoryURL.appending(path: "clearance")
+
+    var privilegedRunnerCalled = false
+    let runner = ClearanceCommandLineToolInstaller.PrivilegedRunner { _, _, _ in
+        privilegedRunnerCalled = true
+    }
+
+    try ClearanceCommandLineToolInstaller.install(
+        helperExecutableURL: helperURL,
+        at: installURL,
+        privilegedRunner: runner
+    )
+
+    XCTAssertTrue(privilegedRunnerCalled)
+}
+
+func testPrivilegedInstallCancellationIsSilent() throws {
+    let helperURL = try makeExecutable(named: "clearance")
+    let installDirectoryURL = try makeNonWritableDirectory()
+    let installURL = installDirectoryURL.appending(path: "clearance")
+
+    let cancellingRunner = ClearanceCommandLineToolInstaller.PrivilegedRunner { _, _, _ in
+        throw ClearanceCommandLineToolInstallerError.privilegedInstallCancelled
+    }
+
+    XCTAssertNoThrow(
+        try ClearanceCommandLineToolInstaller.install(
+            helperExecutableURL: helperURL,
+            at: installURL,
+            privilegedRunner: cancellingRunner
+        )
+    )
+}
+
+func testPrivilegedInstallSurfacesHelperError() throws {
+    let helperURL = try makeExecutable(named: "clearance")
+    let installDirectoryURL = try makeNonWritableDirectory()
+    let installURL = installDirectoryURL.appending(path: "clearance")
+
+    let failingRunner = ClearanceCommandLineToolInstaller.PrivilegedRunner { _, _, _ in
+        throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed("helper said no")
+    }
+
+    XCTAssertThrowsError(
+        try ClearanceCommandLineToolInstaller.install(
+            helperExecutableURL: helperURL,
+            at: installURL,
+            privilegedRunner: failingRunner
+        )
+    ) { error in
+        XCTAssertEqual(
+            error as? ClearanceCommandLineToolInstallerError,
+            .privilegedInstallFailed("helper said no")
+        )
+    }
+}
+
+private func makeNonWritableDirectory() throws -> URL {
+    let url = try makeDirectory().appending(path: "bin", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: url.path)
+    addTeardownBlock {
+        try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+    return url
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceCommandLineInstallerTests/testPrivilegedInstallIsAttemptedWhenDirectoryNotWritable 2>&1 | grep -E "(passed|failed|error:)"
+```
+
+Expected: FAILED (compile error — `PrivilegedRunner` and new error cases don't exist yet)
+
+- [ ] **Step 3: Implement the privileged fallback**
+
+Replace the entire `ClearanceCommandLineToolInstaller.swift`:
+
+```swift
+import Foundation
+import Security
+
+enum ClearanceCommandLineToolInstallerError: LocalizedError, Equatable {
+    case existingInstallIsNotASymlink(URL)
+    case installDirectoryNotWritable(URL)
+    case privilegedInstallCancelled
+    case privilegedInstallFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .existingInstallIsNotASymlink(let url):
+            return "\(url.path) already exists and is not a symlink."
+        case .installDirectoryNotWritable(let url):
+            return "\(url.path) is not writable. Could not obtain admin privileges."
+        case .privilegedInstallCancelled:
+            return nil
+        case .privilegedInstallFailed(let message):
+            return message
+        }
+    }
+}
+
+struct ClearanceCommandLineToolInstaller {
+    struct PrivilegedRunner {
+        var run: (_ helperBinary: URL, _ source: URL, _ destination: URL) throws -> Void
+
+        init(_ run: @escaping (_ helperBinary: URL, _ source: URL, _ destination: URL) throws -> Void) {
+            self.run = run
+        }
+
+        static let live = PrivilegedRunner { helperBinary, source, destination in
+            var authRef: AuthorizationRef?
+            let createStatus = AuthorizationCreate(nil, nil, [], &authRef)
+            guard createStatus == errSecSuccess, let authRef else {
+                throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed(
+                    "Authorization failed (\(createStatus))."
+                )
+            }
+            defer { AuthorizationFree(authRef, [.destroyRights]) }
+
+            var copyStatus: OSStatus = errSecSuccess
+            "system.privilege.admin".withCString { nameCStr in
+                var item = AuthorizationItem(name: nameCStr, valueLength: 0, value: nil, flags: 0)
+                withUnsafeMutablePointer(to: &item) { itemPtr in
+                    var rights = AuthorizationRights(count: 1, items: itemPtr)
+                    copyStatus = AuthorizationCopyRights(
+                        authRef, &rights, nil,
+                        [.interactionAllowed, .extendRights, .preAuthorize],
+                        nil
+                    )
+                }
+            }
+
+            if copyStatus == errAuthorizationCanceled {
+                throw ClearanceCommandLineToolInstallerError.privilegedInstallCancelled
+            }
+            guard copyStatus == errSecSuccess else {
+                throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed(
+                    "Authorization failed (\(copyStatus))."
+                )
+            }
+
+            var pipe: UnsafeMutablePointer<FILE>? = nil
+            var execStatus: OSStatus = errSecSuccess
+            source.path.withCString { sourceCStr in
+                destination.path.withCString { destCStr in
+                    var args: [UnsafeMutablePointer<CChar>?] = [
+                        UnsafeMutablePointer(mutating: sourceCStr),
+                        UnsafeMutablePointer(mutating: destCStr),
+                        nil
+                    ]
+                    execStatus = AuthorizationExecuteWithPrivileges(
+                        authRef, helperBinary.path, [], &args, &pipe
+                    )
+                }
+            }
+
+            guard execStatus == errSecSuccess else {
+                throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed(
+                    "Could not launch installer (\(execStatus))."
+                )
+            }
+
+            var output = ""
+            if let pipe {
+                var buffer = [CChar](repeating: 0, count: 512)
+                while fgets(&buffer, Int32(buffer.count), pipe) != nil {
+                    output += String(cString: buffer)
+                }
+                fclose(pipe)
+            }
+
+            let message = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !message.isEmpty {
+                throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed(message)
+            }
+        }
+    }
+
+    static let installURL = URL(fileURLWithPath: "/usr/local/bin/clearance")
+
+    static func install(
+        helperExecutableURL: URL,
+        at installURL: URL = installURL,
+        fileManager: FileManager = .default,
+        privilegedRunner: PrivilegedRunner = .live
+    ) throws {
+        let installDirectoryURL = installURL.deletingLastPathComponent()
+        let directoryExists = fileManager.fileExists(atPath: installDirectoryURL.path)
+        let directoryWritable = fileManager.isWritableFile(atPath: installDirectoryURL.path)
+
+        if directoryExists && !directoryWritable {
+            try installWithPrivileges(
+                helperExecutableURL: helperExecutableURL,
+                installURL: installURL,
+                privilegedRunner: privilegedRunner
+            )
+            return
+        }
+
+        do {
+            try fileManager.createDirectory(
+                at: installDirectoryURL,
+                withIntermediateDirectories: true
+            )
+        } catch let error as NSError
+            where error.domain == NSCocoaErrorDomain && error.code == NSFileWriteNoPermissionError
+        {
+            try installWithPrivileges(
+                helperExecutableURL: helperExecutableURL,
+                installURL: installURL,
+                privilegedRunner: privilegedRunner
+            )
+            return
+        }
+
+        if (try? fileManager.destinationOfSymbolicLink(atPath: installURL.path)) != nil {
+            try fileManager.removeItem(at: installURL)
+        } else if fileManager.fileExists(atPath: installURL.path) {
+            throw ClearanceCommandLineToolInstallerError.existingInstallIsNotASymlink(installURL)
+        }
+
+        do {
+            try fileManager.createSymbolicLink(at: installURL, withDestinationURL: helperExecutableURL)
+        } catch let error as NSError
+            where error.domain == NSCocoaErrorDomain && error.code == NSFileWriteNoPermissionError
+        {
+            try installWithPrivileges(
+                helperExecutableURL: helperExecutableURL,
+                installURL: installURL,
+                privilegedRunner: privilegedRunner
+            )
+        }
+    }
+
+    private static func installWithPrivileges(
+        helperExecutableURL: URL,
+        installURL: URL,
+        privilegedRunner: PrivilegedRunner
+    ) throws {
+        guard let installHelperURL = Bundle.main.url(
+            forAuxiliaryExecutable: "ClearanceInstallHelper"
+        ) else {
+            throw ClearanceCommandLineToolInstallerError.privilegedInstallFailed(
+                "ClearanceInstallHelper not found in app bundle."
+            )
+        }
+
+        do {
+            try privilegedRunner.run(installHelperURL, helperExecutableURL, installURL)
+        } catch ClearanceCommandLineToolInstallerError.privilegedInstallCancelled {
+            return  // Silent no-op — user's intent is clear
+        }
+        // All other errors propagate to the caller
+    }
+}
+```
+
+- [ ] **Step 4: Run all installer tests**
+
+```bash
+xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceCommandLineInstallerTests 2>&1 | grep -E "(passed|failed)"
+```
+
+Expected: All passing (existing 4 tests + 3 new ones).
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' 2>&1 | grep -E "(Executed|BUILD)"
+```
+
+Expected: `** BUILD SUCCEEDED **` with 0 failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Clearance/Services/ClearanceCommandLineToolInstaller.swift ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift
+git commit -m "Add privileged install fallback to ClearanceCommandLineToolInstaller"
+```
+
+---
+
+## Task 8: Manual smoke test
+
+This step cannot be automated — it requires a real auth dialog.
+
+- [ ] **Step 1: Build and run the app**
+
+In Xcode: open `Clearance.xcodeproj`, build and run the `Clearance` scheme.
+
+- [ ] **Step 2: Trigger installation**
+
+Open Settings → click "Install Command-Line Tool". On a standard system where `/usr/local/bin` is owned by root, the inline macOS "enter your password" auth sheet should appear.
+
+- [ ] **Step 3: Enter admin credentials and verify**
+
+After authenticating:
+
+```bash
+ls -la /usr/local/bin/clearance
+# Expected: /usr/local/bin/clearance -> /path/to/Clearance.app/Contents/Helpers/clearance
+clearance --help
+```
+
+- [ ] **Step 4: Verify cancellation is silent**
+
+Click "Install Command-Line Tool" again. Press Cancel in the auth sheet. Settings should return to idle with no error message shown.

--- a/docs/superpowers/specs/2026-03-20-privileged-cli-installer-design.md
+++ b/docs/superpowers/specs/2026-03-20-privileged-cli-installer-design.md
@@ -110,6 +110,20 @@ with the helper breaks the app bundle's signature, which Gatekeeper catches.
 **No shell interpretation.** The helper uses `FileManager` directly to create the
 symlink — no `NSTask`, no shell — eliminating shell expansion as an attack surface.
 
+**Code signing identity verification.** The helper verifies that the source binary
+is signed with the same Team ID as itself before creating the symlink:
+
+1. Call `SecCodeCopySelf` to obtain the helper's own code object, then
+   `SecCodeCopySigningInformation` to extract its `kSecCodeInfoTeamIdentifier`.
+2. Call `SecStaticCodeCreateWithPath` on the source binary, then
+   `SecCodeCopySigningInformation` to extract its Team ID.
+3. Reject the source if the Team IDs do not match.
+
+Using the Team ID (rather than a specific certificate CN) means this check survives
+certificate renewals. It ensures the binary promoted to `/usr/local/bin` was signed
+by the same developer as the helper itself. The Security framework is added as a
+dependency of `ClearanceInstallHelper`.
+
 **Symlink atomicity.** Removing the existing symlink and creating the new one are
 two separate operations; a crash between them would leave the destination absent.
 The window is small and the consequence is recoverable (re-run the installer), so
@@ -130,6 +144,7 @@ this trade-off is acceptable.
 **`ClearanceInstallHelper` (unit tests):**
 - Rejects an invalid destination path
 - Rejects a source path that does not begin with the helper's derived bundle root
+- Rejects a source binary whose Team ID does not match the helper's own Team ID
 - Creates the symlink when arguments are valid (temp directory)
 - Replaces an existing symlink at the destination
 - Writes nothing on success; writes a single-line error message to stdout on failure
@@ -147,7 +162,7 @@ verify the symlink is created.
 ## Build Configuration
 
 Add to `project.yml`:
-- A new `ClearanceInstallHelper` tool target with `ENABLE_HARDENED_RUNTIME: YES`
-  and `SWIFT_VERSION: 6.0`
+- A new `ClearanceInstallHelper` tool target with `ENABLE_HARDENED_RUNTIME: YES`,
+  `SWIFT_VERSION: 6.0`, and a link dependency on the `Security` framework
 - An embed + copy dependency from `Clearance` to `ClearanceInstallHelper`, placing
   it at `Contents/Helpers/ClearanceInstallHelper`

--- a/docs/superpowers/specs/2026-03-20-privileged-cli-installer-design.md
+++ b/docs/superpowers/specs/2026-03-20-privileged-cli-installer-design.md
@@ -88,10 +88,12 @@ The existing UI already displays errors from the installer. No changes needed.
 acting:
 - The destination must be exactly `/usr/local/bin/clearance`. Any other path is
   rejected, preventing a compromised caller from creating arbitrary symlinks as root.
-- The source must be a readable file whose path both begins with `/Applications/`
-  and ends with `Contents/Helpers/clearance`. Checking the suffix alone would allow
-  path traversal (e.g. `/tmp/evil/Contents/Helpers/clearance`); checking the prefix
-  constrains the source to the standard app installation location.
+- The source must be a readable file within the same app bundle as the helper itself.
+  The helper derives the bundle root from its own executable path
+  (`CommandLine.arguments[0]`) by removing three path components
+  (`ClearanceInstallHelper` → `Helpers` → `Contents` → bundle root). It then
+  verifies the source path begins with that bundle root. This approach works wherever
+  the app is installed and prevents path traversal without hardcoding any prefix.
 
 **App-side path construction.** The app constructs both paths from
 `Bundle.main.bundleURL`, never from user input. There is no injection surface.
@@ -127,7 +129,7 @@ this trade-off is acceptable.
 
 **`ClearanceInstallHelper` (unit tests):**
 - Rejects an invalid destination path
-- Rejects a source path that does not end with `Contents/Helpers/clearance`
+- Rejects a source path that does not begin with the helper's derived bundle root
 - Creates the symlink when arguments are valid (temp directory)
 - Replaces an existing symlink at the destination
 - Writes nothing on success; writes a single-line error message to stdout on failure

--- a/docs/superpowers/specs/2026-03-20-privileged-cli-installer-design.md
+++ b/docs/superpowers/specs/2026-03-20-privileged-cli-installer-design.md
@@ -1,0 +1,151 @@
+# Privileged CLI Installer Design
+
+**Date:** 2026-03-20
+**Status:** Draft
+
+## Problem
+
+The Clearance app ships a `clearance` CLI tool and offers an "Install Command-Line
+Tool" button in Settings. The installer creates a symlink at `/usr/local/bin/clearance`
+pointing to the bundled helper binary. `/usr/local/bin` is owned by root, so the
+installation fails with a permission error on any system where the user lacks write
+access — which is most systems.
+
+## Goal
+
+When direct symlink creation fails due to a permission error, prompt the user for
+their admin password and complete the installation with elevated privileges. The auth
+dialog must appear inline (the native macOS "enter your password" sheet), not redirect
+to System Settings.
+
+## Approach
+
+Authorization Services + a one-shot privileged helper binary (`ClearanceInstallHelper`).
+
+The app calls `AuthorizationCreate` to obtain an authorization reference, then
+`AuthorizationCopyRights` requesting `"system.privilege.admin"` to show the inline
+auth dialog. On success, it calls `AuthorizationExecuteWithPrivileges` to spawn
+`ClearanceInstallHelper` as root. The helper creates the symlink and exits. No daemon
+is installed; nothing persists after the operation completes.
+
+`AuthorizationExecuteWithPrivileges` is deprecated since macOS 10.7 but remains
+available on macOS 14. Apple has not announced a replacement and it is the only
+non-daemon mechanism for spawning a helper as root with an inline auth prompt.
+
+## Components
+
+### `ClearanceInstallHelper` (new)
+
+A minimal Swift `tool` target, bundled at `Contents/Helpers/ClearanceInstallHelper`.
+
+**Responsibilities:**
+- Validate arguments (see Security below)
+- Remove any existing symlink at the destination
+- Create the symlink from destination to source
+- Write nothing to stdout on success; write a single-line error message to stdout
+  and exit non-zero on failure
+
+**Arguments:** `ClearanceInstallHelper <source> <destination>`
+
+- `source` — path to the `clearance` binary inside the app bundle
+- `destination` — the symlink to create (must be `/usr/local/bin/clearance`)
+
+The helper communicates success and failure over stdout because
+`AuthorizationExecuteWithPrivileges` returns a `FILE*` connected to the helper's
+stdout and does not return the child PID (making exit-code retrieval unreliable).
+The protocol is simple: the helper writes nothing on success, or a single-line error
+message on failure. The app reads from the pipe to EOF; a non-empty result signals
+failure.
+
+The helper has no framework dependencies beyond Foundation.
+
+### `ClearanceCommandLineToolInstaller` (modified)
+
+The existing installer already handles the case where `/usr/local/bin` is writable.
+This change adds a privileged fallback triggered by a permission error.
+
+**New flow:**
+1. Attempt direct symlink creation (existing behaviour).
+2. If a permission error is returned, proceed to the privileged code path.
+3. Call `AuthorizationCreate` to obtain an `AuthorizationRef`.
+4. Call `AuthorizationCopyRights` requesting `"system.privilege.admin"`. macOS
+   shows the inline auth dialog.
+5. If the user cancels (`errAuthorizationCanceled`), return without error — the
+   user's intent is clear and showing an error would be misleading.
+6. On success, call `AuthorizationExecuteWithPrivileges` with the full path to
+   `ClearanceInstallHelper` and the source and destination paths as arguments.
+7. Read from the returned `FILE*` pipe to EOF. An empty result means success; a
+   non-empty result is the error message. Close the pipe with `fclose`.
+8. If an error message was received, surface it in Settings.
+
+### `SettingsView` (unchanged)
+
+The existing UI already displays errors from the installer. No changes needed.
+
+## Security
+
+**Argument validation in the helper.** The helper validates both arguments before
+acting:
+- The destination must be exactly `/usr/local/bin/clearance`. Any other path is
+  rejected, preventing a compromised caller from creating arbitrary symlinks as root.
+- The source must be a readable file whose path both begins with `/Applications/`
+  and ends with `Contents/Helpers/clearance`. Checking the suffix alone would allow
+  path traversal (e.g. `/tmp/evil/Contents/Helpers/clearance`); checking the prefix
+  constrains the source to the standard app installation location.
+
+**App-side path construction.** The app constructs both paths from
+`Bundle.main.bundleURL`, never from user input. There is no injection surface.
+The helper's validation provides defence in depth.
+
+**Hardened runtime.** `ClearanceInstallHelper` is built with
+`ENABLE_HARDENED_RUNTIME = YES`. No additional entitlements are required for
+`AuthorizationExecuteWithPrivileges` from a hardened binary. This prevents code
+injection into the helper process while it runs as root.
+
+**Code signing.** The helper is signed automatically alongside the app. Tampering
+with the helper breaks the app bundle's signature, which Gatekeeper catches.
+
+**No shell interpretation.** The helper uses `FileManager` directly to create the
+symlink — no `NSTask`, no shell — eliminating shell expansion as an attack surface.
+
+**Symlink atomicity.** Removing the existing symlink and creating the new one are
+two separate operations; a crash between them would leave the destination absent.
+The window is small and the consequence is recoverable (re-run the installer), so
+this trade-off is acceptable.
+
+## Error Handling
+
+| Situation | Behaviour |
+|---|---|
+| User cancels auth dialog | Silent cancellation; button resets, no error shown |
+| `AuthorizationCopyRights` fails (non-cancel) | Map `OSStatus` to a readable message; display in Settings |
+| `AuthorizationExecuteWithPrivileges` fails | Map `OSStatus` to a readable message; display in Settings |
+| Helper exits non-zero | Read stdout pipe contents; display in Settings |
+| Helper binary missing | Fail fast before calling `AuthorizationExecuteWithPrivileges`; surface an internal error |
+
+## Testing
+
+**`ClearanceInstallHelper` (unit tests):**
+- Rejects an invalid destination path
+- Rejects a source path that does not end with `Contents/Helpers/clearance`
+- Creates the symlink when arguments are valid (temp directory)
+- Replaces an existing symlink at the destination
+- Writes nothing on success; writes a single-line error message to stdout on failure
+
+**`ClearanceCommandLineToolInstaller` (existing + new unit tests):**
+- Existing tests cover the direct (non-privileged) path; these must continue to pass.
+- New tests cover error mapping: `errAuthorizationCanceled` produces no error;
+  a non-zero helper exit status produces an error with the pipe contents.
+
+**The privileged path end-to-end** cannot be automated (it requires a real auth
+dialog). A manual smoke test suffices: click "Install Command-Line Tool" in Settings
+on a system where `/usr/local/bin` is not writable, enter the admin password, and
+verify the symlink is created.
+
+## Build Configuration
+
+Add to `project.yml`:
+- A new `ClearanceInstallHelper` tool target with `ENABLE_HARDENED_RUNTIME: YES`
+  and `SWIFT_VERSION: 6.0`
+- An embed + copy dependency from `Clearance` to `ClearanceInstallHelper`, placing
+  it at `Contents/Helpers/ClearanceInstallHelper`

--- a/project.yml
+++ b/project.yml
@@ -93,6 +93,7 @@ schemes:
     build:
       targets:
         Clearance: all
+        ClearanceInstallHelper: all
         ClearanceTests: [test]
     run:
       config: Debug

--- a/project.yml
+++ b/project.yml
@@ -32,6 +32,7 @@ targets:
         CURRENT_PROJECT_VERSION: 12
         SPARKLE_FEED_URL: ""
         SPARKLE_PUBLIC_ED_KEY: ""
+        DEFINES_MODULE: YES
     dependencies:
       - package: Yams
       - package: Markdown
@@ -66,6 +67,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.jesse.ClearanceTests
         GENERATE_INFOPLIST_FILE: YES
         SWIFT_VERSION: 6.0
+        SWIFT_ENABLE_EXPLICIT_MODULES: NO
+        SWIFT_INCLUDE_PATHS: $(OBJROOT)/Clearance.build/$(CONFIGURATION)/Clearance.build/Objects-normal/$(NATIVE_ARCH_ACTUAL)
 schemes:
   Clearance:
     build:

--- a/project.yml
+++ b/project.yml
@@ -43,6 +43,12 @@ targets:
         copy:
           destination: wrapper
           subpath: Contents/Helpers
+      - target: ClearanceInstallHelper
+        link: false
+        embed: true
+        copy:
+          destination: wrapper
+          subpath: Contents/Helpers
   ClearanceCLI:
     type: tool
     platform: macOS
@@ -55,11 +61,24 @@ targets:
       base:
         PRODUCT_NAME: clearance
         SWIFT_VERSION: 6.0
+  ClearanceInstallHelper:
+    type: tool
+    platform: macOS
+    sources:
+      - path: ClearanceInstallHelper
+    settings:
+      base:
+        PRODUCT_NAME: ClearanceInstallHelper
+        SWIFT_VERSION: 6.0
+        ENABLE_HARDENED_RUNTIME: YES
+    dependencies:
+      - sdk: Security.framework
   ClearanceTests:
     type: bundle.unit-test
     platform: macOS
     sources:
       - path: ClearanceTests
+      - path: ClearanceInstallHelper/HelperInstaller.swift
     dependencies:
       - target: Clearance
     settings:


### PR DESCRIPTION
## Summary

- Adds `ClearanceInstallHelper`, a minimal privileged helper binary bundled at `Contents/Helpers/ClearanceInstallHelper`
- When the direct symlink creation fails due to a permission error, uses Authorization Services to show the native macOS inline auth dialog, then spawns the helper as root via `AuthorizationExecuteWithPrivileges`
- The helper validates arguments (destination must be `/usr/local/bin/clearance`, source must be inside the same app bundle, Team IDs must match), then creates the symlink
- Success/failure communicated via stdout pipe (empty = success, message = failure)
- Cancelling the auth dialog clears any previous status message in Settings rather than showing a spurious success

## Design

Full design spec: `docs/superpowers/specs/2026-03-20-privileged-cli-installer-design.md`

Key security properties:
- Destination path hard-validated to `/usr/local/bin/clearance` — no arbitrary symlink creation
- Source path validated to be within the same app bundle as the helper (derived from the helper's own executable path, not a hardcoded prefix)
- Source binary must be signed with the same Team ID as the helper (survives certificate renewals; allows unsigned dev builds)
- Helper built with hardened runtime — no code injection while running as root
- No shell invocation — `FileManager` only, no expansion surface

## Notes

- `AuthorizationExecuteWithPrivileges` is deprecated since macOS 10.7 but remains functional on macOS 14 (the deployment target). Apple has not provided a non-daemon replacement for one-shot privileged operations.
- The Swift overlay does not expose `AuthorizationExecuteWithPrivileges` directly; a `@_silgen_name` redeclaration is used to call the underlying C symbol.

## Test plan

- [ ] Unit tests for `HelperInstaller`: destination validation, source path validation, Team ID verification, symlink creation (9 tests)
- [ ] Unit tests for `ClearanceCommandLineToolInstaller`: privileged runner invoked on non-writable directory, cancellation propagates, helper errors surface (3 new tests + 3 existing passing)
- [ ] Manual smoke test: click "Install Command-Line Tool" in Settings on a system where `/usr/local/bin` is root-owned → password prompt appears → after authenticating, `ls -la /usr/local/bin/clearance` shows correct symlink and `clearance --help` works
- [ ] Manual cancel test: click "Install Command-Line Tool" → Cancel in auth dialog → Settings returns to idle with no message

🤖 Generated with [Claude Code](https://claude.com/claude-code)