### PR TITLE
Option to use ~/.local/bin

### DIFF
--- a/Clearance/Services/ClearanceCommandLineToolInstaller.swift
+++ b/Clearance/Services/ClearanceCommandLineToolInstaller.swift
@@ -1,9 +1,35 @@
 import AppKit
 import Foundation
 
+enum CLIInstallLocation: String, CaseIterable, Identifiable {
+    case usrLocalBin
+    case dotLocalBin
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .usrLocalBin: "/usr/local/bin"
+        case .dotLocalBin: "~/.local/bin"
+        }
+    }
+
+    var directoryURL: URL {
+        switch self {
+        case .usrLocalBin:
+            URL(fileURLWithPath: "/usr/local/bin", isDirectory: true)
+        case .dotLocalBin:
+            FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".local/bin", isDirectory: true)
+        }
+    }
+}
+
 enum ClearanceCommandLineToolInstallerError: LocalizedError, Equatable {
     case bundledInstallerNotFound
     case installerLaunchFailed(URL)
+    case helperExecutableNotFound
+    case symlinkFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -11,6 +37,10 @@ enum ClearanceCommandLineToolInstallerError: LocalizedError, Equatable {
             return "Bundled command-line installer package not found."
         case .installerLaunchFailed(let url):
             return "Could not open \(url.lastPathComponent) in Installer."
+        case .helperExecutableNotFound:
+            return "Command-line helper executable not found in app bundle."
+        case .symlinkFailed(let reason):
+            return "Could not create symlink: \(reason)"
         }
     }
 }
@@ -34,8 +64,29 @@ struct ClearanceCommandLineToolInstaller {
     }
 
     static func install(
+        to location: CLIInstallLocation,
+        bundle: Bundle = .main,
+        workspace: WorkspaceOpening = NSWorkspace.shared,
+        fileManager: FileManager = .default
+    ) throws {
+        switch location {
+        case .usrLocalBin:
+            try installViaPackage(bundle: bundle, workspace: workspace)
+        case .dotLocalBin:
+            try installViaSymlink(bundle: bundle, directoryURL: location.directoryURL, fileManager: fileManager)
+        }
+    }
+
+    static func install(
         bundle: Bundle = .main,
         workspace: WorkspaceOpening = NSWorkspace.shared
+    ) throws {
+        try installViaPackage(bundle: bundle, workspace: workspace)
+    }
+
+    private static func installViaPackage(
+        bundle: Bundle,
+        workspace: WorkspaceOpening
     ) throws {
         guard let packageURL = installerPackageURL(in: bundle) else {
             throw ClearanceCommandLineToolInstallerError.bundledInstallerNotFound
@@ -43,6 +94,40 @@ struct ClearanceCommandLineToolInstaller {
 
         guard workspace.open(packageURL) else {
             throw ClearanceCommandLineToolInstallerError.installerLaunchFailed(packageURL)
+        }
+    }
+
+    static func installViaSymlink(
+        bundle: Bundle = .main,
+        directoryURL: URL = CLIInstallLocation.dotLocalBin.directoryURL,
+        fileManager: FileManager = .default
+    ) throws {
+        guard let helperURL = ClearanceCommandLineTool.helperExecutableURL(in: bundle) else {
+            throw ClearanceCommandLineToolInstallerError.helperExecutableNotFound
+        }
+
+        let symlinkURL = directoryURL.appendingPathComponent(ClearanceCommandLineTool.name)
+
+        if !fileManager.fileExists(atPath: directoryURL.path) {
+            do {
+                try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+            } catch {
+                throw ClearanceCommandLineToolInstallerError.symlinkFailed(error.localizedDescription)
+            }
+        }
+
+        if fileManager.fileExists(atPath: symlinkURL.path) {
+            do {
+                try fileManager.removeItem(at: symlinkURL)
+            } catch {
+                throw ClearanceCommandLineToolInstallerError.symlinkFailed(error.localizedDescription)
+            }
+        }
+
+        do {
+            try fileManager.createSymbolicLink(at: symlinkURL, withDestinationURL: helperURL)
+        } catch {
+            throw ClearanceCommandLineToolInstallerError.symlinkFailed(error.localizedDescription)
         }
     }
 }

--- a/Clearance/Views/SettingsView.swift
+++ b/Clearance/Views/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @ObservedObject var settings: AppSettings
+    @State private var installLocation: CLIInstallLocation = .dotLocalBin
     @State private var commandLineToolStatus: String?
     @State private var commandLineToolStatusIsError = false
 
@@ -41,18 +42,27 @@ struct SettingsView: View {
             Divider()
 
             VStack(alignment: .leading, spacing: 8) {
+                Picker("Install Location", selection: $installLocation) {
+                    ForEach(CLIInstallLocation.allCases) { location in
+                        Text(location.title).tag(location)
+                    }
+                }
+                .pickerStyle(.segmented)
+
                 Button("Install Command-Line Tool") {
                     installCommandLineTool()
                 }
 
-                Text("Adds `clearance` to `/usr/local/bin` so Terminal can open files and folders in Clearance. That location may require admin privileges on some Macs.")
+                Text(commandLineToolDescription)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 if let commandLineToolStatus {
                     Text(commandLineToolStatus)
                         .font(.caption)
                         .foregroundStyle(commandLineToolStatusIsError ? .red : .secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }
@@ -60,10 +70,24 @@ struct SettingsView: View {
         .frame(width: 440)
     }
 
+    private var commandLineToolDescription: String {
+        switch installLocation {
+        case .usrLocalBin:
+            "Adds `clearance` to `/usr/local/bin` so Terminal can open files and folders in Clearance. Opens a package installer that may require admin privileges."
+        case .dotLocalBin:
+            "Adds `clearance` to `~/.local/bin` so Terminal can open files and folders in Clearance. No admin privileges required."
+        }
+    }
+
     private func installCommandLineTool() {
         do {
-            try ClearanceCommandLineToolInstaller.install()
-            commandLineToolStatus = "Opened the command-line installer package in Installer."
+            try ClearanceCommandLineToolInstaller.install(to: installLocation)
+            switch installLocation {
+            case .usrLocalBin:
+                commandLineToolStatus = "Opened the command-line installer package in Installer."
+            case .dotLocalBin:
+                commandLineToolStatus = "Symlink created at ~/.local/bin/clearance."
+            }
             commandLineToolStatusIsError = false
         } catch {
             commandLineToolStatus = error.localizedDescription

--- a/Clearance/Views/SettingsView.swift
+++ b/Clearance/Views/SettingsView.swift
@@ -41,28 +41,31 @@ struct SettingsView: View {
 
             Divider()
 
-            VStack(alignment: .leading, spacing: 8) {
-                Picker("Install Location", selection: $installLocation) {
-                    ForEach(CLIInstallLocation.allCases) { location in
-                        Text(location.title).tag(location)
+            Picker("Install Location", selection: $installLocation) {
+                ForEach(CLIInstallLocation.allCases) { location in
+                    Text(location.title).tag(location)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            LabeledContent("") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Button("Install Command-Line Tool") {
+                        installCommandLineTool()
                     }
-                }
-                .pickerStyle(.segmented)
 
-                Button("Install Command-Line Tool") {
-                    installCommandLineTool()
-                }
-
-                Text(commandLineToolDescription)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                if let commandLineToolStatus {
-                    Text(commandLineToolStatus)
+                    Text(commandLineToolDescription)
                         .font(.caption)
-                        .foregroundStyle(commandLineToolStatusIsError ? .red : .secondary)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                         .fixedSize(horizontal: false, vertical: true)
+
+                    if let commandLineToolStatus {
+                        Text(commandLineToolStatus)
+                            .font(.caption)
+                            .foregroundStyle(commandLineToolStatusIsError ? .red : .secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
             }
         }
@@ -71,11 +74,12 @@ struct SettingsView: View {
     }
 
     private var commandLineToolDescription: String {
+        let prefix = "Adds clearance command-line script to open files and folders in Clearance."
         switch installLocation {
         case .usrLocalBin:
-            "Adds `clearance` to `/usr/local/bin` so Terminal can open files and folders in Clearance. Opens a package installer that may require admin privileges."
+            return "\(prefix) May require admin privileges."
         case .dotLocalBin:
-            "Adds `clearance` to `~/.local/bin` so Terminal can open files and folders in Clearance. No admin privileges required."
+            return "\(prefix) No admin privileges required."
         }
     }
 

--- a/ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift
+++ b/ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift
@@ -53,7 +53,98 @@ final class ClearanceCommandLineInstallerTests: XCTestCase {
         }
     }
 
-    private func makeBundle(includesPackage: Bool) throws -> URL {
+    // MARK: - Symlink install tests
+
+    func testSymlinkInstallCreatesSymlinkInDirectory() throws {
+        let bundleURL = try makeBundle(includesHelper: true)
+        let bundle = try XCTUnwrap(Bundle(url: bundleURL))
+        let destDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: destDir) }
+
+        try ClearanceCommandLineToolInstaller.installViaSymlink(
+            bundle: bundle,
+            directoryURL: destDir
+        )
+
+        let symlinkURL = destDir.appendingPathComponent(ClearanceCommandLineTool.name)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: symlinkURL.path))
+
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: symlinkURL.path)
+        let expectedHelper = bundleURL
+            .appendingPathComponent("Contents/Helpers/\(ClearanceCommandLineTool.name)")
+        XCTAssertEqual(destination, expectedHelper.path)
+    }
+
+    func testSymlinkInstallCreatesDirectoryIfMissing() throws {
+        let bundleURL = try makeBundle(includesHelper: true)
+        let bundle = try XCTUnwrap(Bundle(url: bundleURL))
+        let destDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("nested", isDirectory: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: destDir.deletingLastPathComponent()) }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destDir.path))
+
+        try ClearanceCommandLineToolInstaller.installViaSymlink(
+            bundle: bundle,
+            directoryURL: destDir
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destDir.path))
+        let symlinkURL = destDir.appendingPathComponent(ClearanceCommandLineTool.name)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: symlinkURL.path))
+    }
+
+    func testSymlinkInstallReplacesExistingSymlink() throws {
+        let bundleURL = try makeBundle(includesHelper: true)
+        let bundle = try XCTUnwrap(Bundle(url: bundleURL))
+        let destDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: destDir) }
+
+        let symlinkURL = destDir.appendingPathComponent(ClearanceCommandLineTool.name)
+        let oldTarget = destDir.appendingPathComponent("old-target")
+        try Data().write(to: oldTarget)
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: oldTarget)
+
+        try ClearanceCommandLineToolInstaller.installViaSymlink(
+            bundle: bundle,
+            directoryURL: destDir
+        )
+
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: symlinkURL.path)
+        let expectedHelper = bundleURL
+            .appendingPathComponent("Contents/Helpers/\(ClearanceCommandLineTool.name)")
+        XCTAssertEqual(destination, expectedHelper.path)
+    }
+
+    func testSymlinkInstallThrowsWhenHelperMissing() throws {
+        let bundleURL = try makeBundle(includesHelper: false)
+        let bundle = try XCTUnwrap(Bundle(url: bundleURL))
+        let destDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+
+        XCTAssertThrowsError(
+            try ClearanceCommandLineToolInstaller.installViaSymlink(
+                bundle: bundle,
+                directoryURL: destDir
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? ClearanceCommandLineToolInstallerError,
+                .helperExecutableNotFound
+            )
+        }
+    }
+
+    // MARK: - Bundle fixture
+
+    private func makeBundle(
+        includesPackage: Bool = false,
+        includesHelper: Bool = false
+    ) throws -> URL {
         let rootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("app")
@@ -87,6 +178,13 @@ final class ClearanceCommandLineInstallerTests: XCTestCase {
                 "\(ClearanceCommandLineToolInstaller.packageFileName)"
             )
             try Data().write(to: packageURL)
+        }
+
+        if includesHelper {
+            let helpersURL = contentsURL.appendingPathComponent("Helpers", isDirectory: true)
+            try FileManager.default.createDirectory(at: helpersURL, withIntermediateDirectories: true)
+            let helperURL = helpersURL.appendingPathComponent(ClearanceCommandLineTool.name)
+            try Data().write(to: helperURL)
         }
 
         return rootURL


### PR DESCRIPTION
Add an option to install the `clearance` script in `~/.local/bin` rather than `/usr/local/bin`