### PR TITLE
Add UTImportedTypeDeclarations for Markdown UTI

### DIFF
--- a/apps/macos/Clearance/App/Info.plist
+++ b/apps/macos/Clearance/App/Info.plist
@@ -69,5 +69,28 @@
 			</array>
 		</dict>
 	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>net.daringfireball.markdown</string>
+			<key>UTTypeDescription</key>
+			<string>Markdown Document</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.plain-text</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>md</string>
+					<string>markdown</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>text/markdown</string>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Adds `UTImportedTypeDeclarations` to Info.plist declaring `net.daringfireball.markdown` UTI
- Without this, macOS assigns `.md` files a dynamic UTI and Clearance doesn't appear in the "Open With" context menu
- The declaration maps `net.daringfireball.markdown` to `.md`/`.markdown` extensions and `text/markdown` MIME type, conforming to `public.plain-text`

## Test plan
- [ ] Build and install Clearance
- [ ] Right-click a `.md` file in Finder → "Open With" should list Clearance
- [ ] Double-clicking a `.md` file should open in Clearance (if set as default)
- [ ] Verify `.txt` files still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)