### PR TITLE
Fix: remove errant horizontal line from outline pane

### DIFF
--- a/apps/macos/Clearance/Views/WorkspaceView.swift
+++ b/apps/macos/Clearance/Views/WorkspaceView.swift
@@ -856,9 +856,6 @@ struct MarkdownOutlineView: View {
             .padding(.vertical, 10)
         }
         .background(Color(nsColor: .windowBackgroundColor))
-        .overlay(alignment: .leading) {
-            Divider()
-        }
         .frame(minWidth: 220, idealWidth: 260, maxWidth: 320)
     }
 


### PR DESCRIPTION
## Summary

A horizontal grey line appeared across the middle of the document outline pane. This is caused by a `Divider()` placed in a `.overlay(alignment: .leading)` modifier on `MarkdownOutlineView`.

The intent was a 1pt vertical left-border to visually separate the outline from the document. However, SwiftUI renders bare `Divider()` views **horizontally** by default. With `.leading` alignment only anchoring the horizontal axis, the vertical position defaulted to centre — producing a horizontal line across the middle of the pane.

The `NSSplitView` already provides visual separation between panes, so the overlay is removed entirely.

## Before

<img width="1353" height="1172" alt="image" src="https://github.com/user-attachments/assets/248b1d44-a319-4f52-bb6f-c5f744c7d900" />

## After

The outline pane no longer has the spurious horizontal line.

## Change

- `MarkdownOutlineView` in `WorkspaceView.swift`: removed `.overlay(alignment: .leading) { Divider() }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)