### PR TITLE
Improve editor responsiveness and syntax highlighting

### DIFF
--- a/apps/macos/Clearance/App/ClearanceApp.swift
+++ b/apps/macos/Clearance/App/ClearanceApp.swift
@@ -20,7 +20,7 @@ struct ClearanceApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        Window("Clearance", id: "main") {
             WorkspaceView(
                 appSettings: appSettings,
                 popoutWindowController: popoutWindowController

--- a/apps/macos/Clearance/Models/DocumentSession.swift
+++ b/apps/macos/Clearance/Models/DocumentSession.swift
@@ -75,6 +75,15 @@ final class DocumentSession: ObservableObject, Identifiable {
             return
         }
 
+        if diskText == content {
+            pendingAutosave?.cancel()
+            pendingAutosave = nil
+            lastKnownDiskText = diskText
+            isDirty = false
+            hasExternalChanges = false
+            return
+        }
+
         hasExternalChanges = true
     }
 

--- a/apps/macos/Clearance/Views/Edit/CodeMirrorEditorView.swift
+++ b/apps/macos/Clearance/Views/Edit/CodeMirrorEditorView.swift
@@ -1,6 +1,13 @@
 import AppKit
 import SwiftUI
 
+@MainActor
+protocol EditorHighlighting: AnyObject {
+    func setPalette(_ newPalette: EditorPalette)
+    func apply(to textView: NSTextView)
+    func apply(to textView: NSTextView, changedRange: NSRange)
+}
+
 struct CodeMirrorEditorView: NSViewRepresentable {
     @Binding var text: String
     let theme: AppTheme
@@ -41,7 +48,7 @@ struct CodeMirrorEditorView: NSViewRepresentable {
         textView.delegate = context.coordinator
         textView.string = text
 
-        context.coordinator.textView = textView
+        context.coordinator.editorTextView = textView
         context.coordinator.applyTheme(to: textView)
         context.coordinator.highlighter.apply(to: textView)
         textView.onAppearanceDidChange = { [weak textView, weak coordinator = context.coordinator] in
@@ -61,58 +68,56 @@ struct CodeMirrorEditorView: NSViewRepresentable {
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         context.coordinator.parent = self
 
-        guard let textView = context.coordinator.textView else {
+        guard let textView = context.coordinator.editorTextView else {
             return
         }
 
-        context.coordinator.applyTheme(to: textView)
-        context.coordinator.highlighter.apply(to: textView)
-
-        guard textView.string != text else {
-            return
-        }
-
-        context.coordinator.isSyncingFromBinding = true
-
-        let oldSelection = textView.selectedRange()
-        textView.string = text
-        context.coordinator.highlighter.apply(to: textView)
-
-        let maxLength = (textView.string as NSString).length
-        let clampedLocation = min(oldSelection.location, maxLength)
-        let clampedLength = min(oldSelection.length, max(0, maxLength - clampedLocation))
-        textView.setSelectedRange(NSRange(location: clampedLocation, length: clampedLength))
-
-        context.coordinator.isSyncingFromBinding = false
+        context.coordinator.updateTextView(textView, with: text)
     }
 
     @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         var parent: CodeMirrorEditorView
-        weak var textView: EditorTextView?
-        let highlighter = MarkdownSyntaxHighlighter()
+        weak var editorTextView: EditorTextView?
+        let highlighter: any EditorHighlighting
         var isSyncingFromBinding = false
+        private var lastStyleKey: EditorStyleKey?
+        private var pendingChangedRange: NSRange?
 
-        init(parent: CodeMirrorEditorView) {
+        init(
+            parent: CodeMirrorEditorView,
+            highlighter: any EditorHighlighting = MarkdownSyntaxHighlighter()
+        ) {
             self.parent = parent
+            self.highlighter = highlighter
         }
 
         func textDidChange(_ notification: Notification) {
             guard !isSyncingFromBinding,
-                  let textView else {
+                  let editorTextView else {
                 return
             }
 
-            highlighter.apply(to: textView)
-            let latest = textView.string
+            let latest = editorTextView.string
             if parent.text != latest {
                 parent.text = latest
             }
+
+            let changedRange = pendingChangedRange ?? editorTextView.selectedRange()
+            pendingChangedRange = nil
+            applyHighlightPreservingScroll(to: editorTextView, changedRange: changedRange)
+        }
+
+        func textView(_ textView: NSTextView, shouldChangeTextIn affectedCharRange: NSRange, replacementString: String?) -> Bool {
+            let replacementLength = (replacementString ?? "").utf16.count
+            pendingChangedRange = NSRange(location: affectedCharRange.location, length: replacementLength)
+            return true
         }
 
         func applyTheme(to textView: NSTextView) {
             let palette = EditorPalette(variant: resolvedThemeVariant(for: textView))
             highlighter.setPalette(palette)
+            lastStyleKey = styleKey(for: textView)
 
             textView.backgroundColor = palette.editorBackground
             textView.textColor = palette.text
@@ -121,6 +126,35 @@ struct CodeMirrorEditorView: NSViewRepresentable {
                 .backgroundColor: palette.selectionBackground,
                 .foregroundColor: palette.selectionText
             ]
+        }
+
+        func updateTextView(_ textView: EditorTextView, with text: String) {
+            let textChanged = textView.string != text
+            let styleChanged = lastStyleKey != styleKey(for: textView)
+
+            guard textChanged || styleChanged else {
+                return
+            }
+
+            if styleChanged {
+                applyTheme(to: textView)
+            }
+
+            if textChanged {
+                isSyncingFromBinding = true
+
+                let oldSelection = textView.selectedRange()
+                textView.string = text
+
+                let maxLength = (textView.string as NSString).length
+                let clampedLocation = min(oldSelection.location, maxLength)
+                let clampedLength = min(oldSelection.length, max(0, maxLength - clampedLocation))
+                textView.setSelectedRange(NSRange(location: clampedLocation, length: clampedLength))
+
+                isSyncingFromBinding = false
+            }
+
+            applyHighlightPreservingScroll(to: textView)
         }
 
         private func resolvedThemeVariant(for textView: NSTextView) -> ThemeVariant {
@@ -135,6 +169,77 @@ struct CodeMirrorEditorView: NSViewRepresentable {
                 return bestMatch == .darkAqua ? palette.dark : palette.light
             }
         }
+
+        private func styleKey(for textView: NSTextView) -> EditorStyleKey {
+            EditorStyleKey(
+                theme: parent.theme,
+                appearance: parent.appearance,
+                resolvedAppearance: resolvedAppearance(for: textView)
+            )
+        }
+
+        private func resolvedAppearance(for textView: NSTextView) -> EditorResolvedAppearance {
+            switch parent.appearance {
+            case .light:
+                return .light
+            case .dark:
+                return .dark
+            case .system:
+                let bestMatch = textView.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua])
+                return bestMatch == .darkAqua ? .dark : .light
+            }
+        }
+
+        private func applyHighlightPreservingScroll(to textView: NSTextView) {
+            let clipView = textView.enclosingScrollView?.contentView
+            let visibleOrigin = clipView?.bounds.origin
+
+            highlighter.apply(to: textView)
+
+            if let clipView,
+               let visibleOrigin {
+                clipView.scroll(to: visibleOrigin)
+                textView.enclosingScrollView?.reflectScrolledClipView(clipView)
+            }
+        }
+
+        private func applyHighlightPreservingScroll(to textView: NSTextView, changedRange: NSRange) {
+            let clipView = textView.enclosingScrollView?.contentView
+            let visibleOrigin = clipView?.bounds.origin
+
+            highlighter.apply(to: textView, changedRange: changedRange)
+
+            if let clipView,
+               let visibleOrigin {
+                clipView.scroll(to: visibleOrigin)
+                textView.enclosingScrollView?.reflectScrolledClipView(clipView)
+            }
+        }
+    }
+}
+
+private struct EditorStyleKey: Equatable {
+    let theme: AppTheme
+    let appearance: AppearancePreference
+    let resolvedAppearance: EditorResolvedAppearance
+}
+
+private enum EditorResolvedAppearance: Equatable {
+    case light
+    case dark
+}
+
+private extension NSRange {
+    func intersects(_ other: NSRange) -> Bool {
+        NSIntersectionRange(self, other).length > 0
+    }
+
+    func intersection(with other: NSRange) -> NSRange {
+        NSIntersectionRange(self, other)
+    }
+
+    func union(with other: NSRange) -> NSRange {
+        NSUnionRange(self, other)
     }
 }
 
@@ -186,7 +291,7 @@ final class EditorTextView: NSTextView {
 }
 
 @MainActor
-final class MarkdownSyntaxHighlighter {
+final class MarkdownSyntaxHighlighter: EditorHighlighting {
     private var palette = EditorPalette.default
     private let headingRegex = try! NSRegularExpression(pattern: "(?m)^(#{1,6})\\s+(.+)$")
     private let frontmatterRegex = try! NSRegularExpression(pattern: "(?s)\\A---\\n.*?\\n---\\n?")
@@ -206,9 +311,10 @@ final class MarkdownSyntaxHighlighter {
     private let yamlLiteralRegex = try! NSRegularExpression(pattern: "\\b(?:true|false|null|yes|no|on|off)\\b", options: [.caseInsensitive])
     private let swiftKeywordRegex = try! NSRegularExpression(pattern: "\\b(?:actor|as|associatedtype|async|await|break|case|catch|class|continue|default|defer|do|else|enum|extension|fallthrough|false|for|func|guard|if|import|in|init|inout|internal|is|let|nil|operator|private|protocol|public|repeat|return|self|static|struct|subscript|super|switch|throw|throws|true|try|typealias|var|where|while)\\b")
     private let jsKeywordRegex = try! NSRegularExpression(pattern: "\\b(?:as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|from|function|if|import|in|instanceof|interface|let|new|null|private|protected|public|readonly|return|static|switch|this|throw|true|try|type|typeof|var|void|while|with|yield)\\b")
+    private let pythonKeywordRegex = try! NSRegularExpression(pattern: "\\b(?:and|as|assert|async|await|break|class|continue|def|del|elif|else|except|false|finally|for|from|global|if|import|in|is|lambda|none|nonlocal|not|or|pass|raise|return|true|try|while|with|yield)\\b", options: [.caseInsensitive])
     private let genericKeywordRegex = try! NSRegularExpression(pattern: "\\b(?:if|else|for|while|switch|case|break|continue|return|func|function|class|struct|enum|let|var|const|import|from|export|true|false|null|nil)\\b")
 
-    fileprivate func setPalette(_ newPalette: EditorPalette) {
+    func setPalette(_ newPalette: EditorPalette) {
         palette = newPalette
     }
 
@@ -223,47 +329,79 @@ final class MarkdownSyntaxHighlighter {
 
         let fullText = storage.string
         let fullTextRange = NSRange(location: 0, length: (fullText as NSString).length)
-        let fencedCodeMatches = fencedCodeRegex.matches(in: fullText, range: fullTextRange)
-
-        for match in frontmatterRegex.matches(in: fullText, range: fullTextRange) {
-            storage.addAttributes(frontmatterAttributes, range: match.range)
-        }
-
-        for match in headingRegex.matches(in: fullText, range: fullTextRange) {
-            let level = max(1, min(match.range(at: 1).length, 6))
-            storage.addAttributes(headingAttributes(for: level), range: match.range)
-        }
-
-        for match in blockquoteRegex.matches(in: fullText, range: fullTextRange) {
-            storage.addAttributes(blockquoteAttributes, range: match.range)
-        }
-
-        for match in listMarkerRegex.matches(in: fullText, range: fullTextRange) {
-            storage.addAttributes(listMarkerAttributes, range: match.range)
-        }
-
-        for match in linkRegex.matches(in: fullText, range: fullTextRange) {
-            storage.addAttributes(linkAttributes, range: match.range)
-        }
-
-        for match in strongRegex.matches(in: fullText, range: fullTextRange) {
-            storage.addAttributes(strongAttributes, range: match.range)
-        }
-
-        for match in emphasisRegex.matches(in: fullText, range: fullTextRange) {
-            storage.addAttributes(emphasisAttributes, range: match.range)
-        }
-
-        for match in inlineCodeRegex.matches(in: fullText, range: fullTextRange) {
-            storage.addAttributes(inlineCodeAttributes, range: match.range)
-        }
-
-        for match in fencedCodeMatches {
-            applyFencedCodeHighlighting(for: match, in: storage, fullText: fullText)
-        }
+        applyMarkdownAttributes(in: fullRange, storage: storage, fullText: fullText, fullTextRange: fullTextRange)
 
         storage.endEditing()
         textView.typingAttributes = baseAttributes
+    }
+
+    func apply(to textView: NSTextView, changedRange: NSRange) {
+        guard let storage = textView.textStorage else {
+            return
+        }
+
+        let fullText = storage.string
+        let fullTextRange = NSRange(location: 0, length: (fullText as NSString).length)
+        let highlightRange = expandedHighlightRange(around: changedRange, fullText: fullText, fullTextRange: fullTextRange)
+
+        guard highlightRange.length > 0 || fullTextRange.length == 0 else {
+            textView.typingAttributes = baseAttributes
+            return
+        }
+
+        storage.beginEditing()
+        if highlightRange.length > 0 {
+            storage.setAttributes(baseAttributes, range: highlightRange)
+            applyMarkdownAttributes(in: highlightRange, storage: storage, fullText: fullText, fullTextRange: fullTextRange)
+        }
+        storage.endEditing()
+        textView.typingAttributes = baseAttributes
+    }
+
+    private func applyMarkdownAttributes(in targetRange: NSRange, storage: NSTextStorage, fullText: String, fullTextRange: NSRange) {
+        let fencedCodeMatches = fencedCodeRegex.matches(in: fullText, range: fullTextRange)
+
+        for match in frontmatterRegex.matches(in: fullText, range: fullTextRange) {
+            addAttributes(frontmatterAttributes, range: match.range, clippedTo: targetRange, in: storage)
+            applyYamlTokenColors(in: storage, fullText: fullText, yamlRange: match.range.intersection(with: targetRange))
+        }
+
+        for match in headingRegex.matches(in: fullText, range: targetRange) {
+            let level = max(1, min(match.range(at: 1).length, 6))
+            addAttributes(headingAttributes(for: level), range: match.range, clippedTo: targetRange, in: storage)
+        }
+
+        for match in blockquoteRegex.matches(in: fullText, range: targetRange) {
+            addAttributes(blockquoteAttributes, range: match.range, clippedTo: targetRange, in: storage)
+        }
+
+        for match in listMarkerRegex.matches(in: fullText, range: targetRange) {
+            addAttributes(listMarkerAttributes, range: match.range, clippedTo: targetRange, in: storage)
+        }
+
+        for match in linkRegex.matches(in: fullText, range: targetRange) {
+            addAttributes(linkAttributes, range: match.range, clippedTo: targetRange, in: storage)
+        }
+
+        for match in strongRegex.matches(in: fullText, range: targetRange) {
+            addAttributes(strongAttributes, range: match.range, clippedTo: targetRange, in: storage)
+        }
+
+        for match in emphasisRegex.matches(in: fullText, range: targetRange) {
+            addAttributes(emphasisAttributes, range: match.range, clippedTo: targetRange, in: storage)
+        }
+
+        for match in inlineCodeRegex.matches(in: fullText, range: targetRange) {
+            addAttributes(inlineCodeAttributes, range: match.range, clippedTo: targetRange, in: storage)
+        }
+
+        for match in fencedCodeMatches {
+            guard match.range.intersects(targetRange) else {
+                continue
+            }
+
+            applyFencedCodeHighlighting(for: match, in: storage, fullText: fullText, targetRange: targetRange)
+        }
     }
 
     private var baseAttributes: [NSAttributedString.Key: Any] {
@@ -366,8 +504,8 @@ final class MarkdownSyntaxHighlighter {
         ]
     }
 
-    private func applyFencedCodeHighlighting(for match: NSTextCheckingResult, in storage: NSTextStorage, fullText: String) {
-        storage.addAttributes(fencedCodeAttributes, range: match.range)
+    private func applyFencedCodeHighlighting(for match: NSTextCheckingResult, in storage: NSTextStorage, fullText: String, targetRange: NSRange) {
+        addAttributes(fencedCodeAttributes, range: match.range, clippedTo: targetRange, in: storage)
 
         let codeRange = match.range(at: 2)
         guard codeRange.location != NSNotFound else {
@@ -382,7 +520,24 @@ final class MarkdownSyntaxHighlighter {
             language = (fullText as NSString).substring(with: languageRange).lowercased()
         }
 
-        applyCodeTokenColors(in: storage, fullText: fullText, codeRange: codeRange, language: language)
+        let targetCodeRange = codeRange.intersection(with: targetRange)
+        guard targetCodeRange.length > 0 else {
+            return
+        }
+
+        applyCodeTokenColors(in: storage, fullText: fullText, codeRange: targetCodeRange, language: language)
+    }
+
+    private func applyYamlTokenColors(in storage: NSTextStorage, fullText: String, yamlRange: NSRange) {
+        guard yamlRange.length > 0 else {
+            return
+        }
+
+        applyRegex(codeNumberRegex, attributes: codeNumberAttributes, in: storage, fullText: fullText, range: yamlRange)
+        applyRegex(yamlLiteralRegex, attributes: codeKeywordAttributes, in: storage, fullText: fullText, range: yamlRange)
+        applyRegex(yamlKeyRegex, attributes: codePropertyAttributes, in: storage, fullText: fullText, range: yamlRange, captureGroup: 1)
+        applyRegex(hashCommentRegex, attributes: codeCommentAttributes, in: storage, fullText: fullText, range: yamlRange)
+        applyRegex(codeStringRegex, attributes: codeStringAttributes, in: storage, fullText: fullText, range: yamlRange)
     }
 
     private func applyCodeTokenColors(in storage: NSTextStorage, fullText: String, codeRange: NSRange, language: String) {
@@ -400,6 +555,9 @@ final class MarkdownSyntaxHighlighter {
         case "bash", "sh", "zsh", "shell":
             applyRegex(hashCommentRegex, attributes: codeCommentAttributes, in: storage, fullText: fullText, range: codeRange)
             applyRegex(genericKeywordRegex, attributes: codeKeywordAttributes, in: storage, fullText: fullText, range: codeRange)
+        case "py", "python", "python3":
+            applyRegex(pythonKeywordRegex, attributes: codeKeywordAttributes, in: storage, fullText: fullText, range: codeRange)
+            applyRegex(hashCommentRegex, attributes: codeCommentAttributes, in: storage, fullText: fullText, range: codeRange)
         case "js", "mjs", "cjs", "jsx", "ts", "tsx", "typescript", "javascript", "json", "jsonc":
             applyRegex(jsKeywordRegex, attributes: codeKeywordAttributes, in: storage, fullText: fullText, range: codeRange)
             applyRegex(codeBlockCommentRegex, attributes: codeCommentAttributes, in: storage, fullText: fullText, range: codeRange)
@@ -425,6 +583,38 @@ final class MarkdownSyntaxHighlighter {
         }
     }
 
+    private func addAttributes(_ attributes: [NSAttributedString.Key: Any], range: NSRange, clippedTo targetRange: NSRange, in storage: NSTextStorage) {
+        let clippedRange = range.intersection(with: targetRange)
+        guard clippedRange.length > 0 else {
+            return
+        }
+
+        storage.addAttributes(attributes, range: clippedRange)
+    }
+
+    private func expandedHighlightRange(around changedRange: NSRange, fullText: String, fullTextRange: NSRange) -> NSRange {
+        guard fullTextRange.length > 0 else {
+            return fullTextRange
+        }
+
+        let nsText = fullText as NSString
+        let location = min(max(0, changedRange.location), fullTextRange.length)
+        let paragraphProbeLocation = min(location, max(0, fullTextRange.length - 1))
+        let paragraphProbeLength = min(max(changedRange.length, 1), fullTextRange.length - paragraphProbeLocation)
+        var range = nsText.paragraphRange(for: NSRange(location: paragraphProbeLocation, length: paragraphProbeLength))
+        range = range.intersection(with: fullTextRange)
+
+        for match in frontmatterRegex.matches(in: fullText, range: fullTextRange) where match.range.intersects(range) {
+            range = range.union(with: match.range)
+        }
+
+        for match in fencedCodeRegex.matches(in: fullText, range: fullTextRange) where match.range.intersects(range) {
+            range = range.union(with: match.range)
+        }
+
+        return range.intersection(with: fullTextRange)
+    }
+
     private func headingAttributes(for level: Int) -> [NSAttributedString.Key: Any] {
         let size: CGFloat
         switch level {
@@ -447,7 +637,7 @@ final class MarkdownSyntaxHighlighter {
     }
 }
 
-fileprivate struct EditorPalette {
+struct EditorPalette {
     let editorBackground: NSColor
     let text: NSColor
     let secondaryText: NSColor

--- a/apps/macos/Clearance/Views/WorkspaceView.swift
+++ b/apps/macos/Clearance/Views/WorkspaceView.swift
@@ -49,7 +49,10 @@ struct WorkspaceView: View {
         } detail: {
             Group {
                 if let session = viewModel.activeSession {
-                    let parsed = FrontmatterParser().parse(markdown: session.content)
+                    let parsed = WorkspaceParsedDocumentBuilder().parsedDocument(
+                        for: session.content,
+                        mode: viewModel.mode
+                    )
                     OutlineSplitView(showsInspector: shouldShowOutline(for: parsed)) {
                         DocumentSurfaceView(
                             session: session,
@@ -827,6 +830,17 @@ private final class ToolbarDelegateProxy: NSObject, NSToolbarDelegate {
             itemIdentifier,
             flag
         )
+    }
+}
+
+struct WorkspaceParsedDocumentBuilder {
+    func parsedDocument(for markdown: String, mode: WorkspaceMode) -> ParsedMarkdownDocument {
+        switch mode {
+        case .view:
+            return FrontmatterParser().parse(markdown: markdown)
+        case .edit:
+            return ParsedMarkdownDocument(body: markdown, flattenedFrontmatter: [:])
+        }
     }
 }
 

--- a/apps/macos/ClearanceTests/Edit/EditorUndoTests.swift
+++ b/apps/macos/ClearanceTests/Edit/EditorUndoTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 import XCTest
 @testable import Clearance
 
@@ -110,5 +111,175 @@ final class EditorUndoTests: XCTestCase {
 
         textView.keyDown(with: event)
         XCTAssertEqual(textView.string, "abcd")
+    }
+
+    func testCoordinatorSkipsHighlightingWhenTextAndStyleAreUnchanged() {
+        let textView = EditorTextView(frame: .zero)
+        textView.string = "abc"
+        let highlighter = CountingEditorHighlighter()
+        let editor = CodeMirrorEditorView(
+            text: .constant("abc"),
+            theme: .apple,
+            appearance: .light
+        )
+        let coordinator = CodeMirrorEditorView.Coordinator(parent: editor, highlighter: highlighter)
+
+        coordinator.updateTextView(textView, with: "abc")
+        XCTAssertEqual(highlighter.applyCount, 1)
+
+        coordinator.updateTextView(textView, with: "abc")
+        XCTAssertEqual(highlighter.applyCount, 1)
+    }
+
+    func testCoordinatorDoesNotRunFullHighlightingDuringTyping() async throws {
+        var boundText = ""
+        let textView = EditorTextView(frame: .zero)
+        let highlighter = CountingEditorHighlighter()
+        let editor = CodeMirrorEditorView(
+            text: Binding(
+                get: { boundText },
+                set: { boundText = $0 }
+            ),
+            theme: .apple,
+            appearance: .light
+        )
+        let coordinator = CodeMirrorEditorView.Coordinator(
+            parent: editor,
+            highlighter: highlighter
+        )
+        coordinator.editorTextView = textView
+
+        textView.string = "first"
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        textView.string = "second"
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+
+        XCTAssertEqual(boundText, "second")
+        XCTAssertEqual(highlighter.applyCount, 0)
+
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        XCTAssertEqual(highlighter.applyCount, 0)
+    }
+
+    func testCoordinatorUsesIncrementalHighlightingDuringTyping() {
+        var boundText = ""
+        let textView = EditorTextView(frame: .zero)
+        let highlighter = CountingEditorHighlighter()
+        let editor = CodeMirrorEditorView(
+            text: Binding(
+                get: { boundText },
+                set: { boundText = $0 }
+            ),
+            theme: .apple,
+            appearance: .light
+        )
+        let coordinator = CodeMirrorEditorView.Coordinator(
+            parent: editor,
+            highlighter: highlighter
+        )
+        coordinator.editorTextView = textView
+
+        let delegate = coordinator as NSTextViewDelegate
+        XCTAssertTrue(delegate.textView?(textView, shouldChangeTextIn: NSRange(location: 0, length: 0), replacementString: "#") ?? false)
+        textView.string = "#"
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+
+        XCTAssertEqual(boundText, "#")
+        XCTAssertEqual(highlighter.applyCount, 0)
+        XCTAssertEqual(highlighter.incrementalApplyCount, 1)
+        XCTAssertEqual(highlighter.lastChangedRange, NSRange(location: 0, length: 1))
+    }
+
+    func testIncrementalHighlightingFormatsChangedHeading() {
+        let textView = EditorTextView(frame: .zero)
+        textView.string = "# Heading\n\nPlain"
+
+        MarkdownSyntaxHighlighter().apply(to: textView, changedRange: NSRange(location: 0, length: 9))
+
+        let font = try? XCTUnwrap(textView.textStorage?.attribute(.font, at: 0, effectiveRange: nil) as? NSFont)
+        XCTAssertEqual(font?.pointSize, 20)
+    }
+
+    func testSyntaxHighlightingColorsFrontmatterYamlTokens() throws {
+        let textView = EditorTextView(frame: .zero)
+        textView.string = """
+        ---
+        title: "Post"
+        published: true
+        count: 42
+        ---
+        # Body
+        """
+
+        MarkdownSyntaxHighlighter().apply(to: textView)
+
+        let palette = EditorPalette(variant: AppTheme.apple.palette.light)
+        XCTAssertColor(atSubstring: "title", in: textView, equals: palette.syntaxProperty)
+        XCTAssertColor(atSubstring: "\"Post\"", in: textView, equals: palette.syntaxString)
+        XCTAssertColor(atSubstring: "true", in: textView, equals: palette.syntaxKeyword)
+        XCTAssertColor(atSubstring: "42", in: textView, equals: palette.syntaxNumber)
+    }
+
+    func testSyntaxHighlightingColorsPythonFencedCodeTokens() throws {
+        let textView = EditorTextView(frame: .zero)
+        textView.string = """
+        ```python
+        def greet(name):
+            return "hi"
+        # comment
+        ```
+        """
+
+        MarkdownSyntaxHighlighter().apply(to: textView)
+
+        let palette = EditorPalette(variant: AppTheme.apple.palette.light)
+        XCTAssertColor(atSubstring: "def", in: textView, equals: palette.syntaxKeyword)
+        XCTAssertColor(atSubstring: "return", in: textView, equals: palette.syntaxKeyword)
+        XCTAssertColor(atSubstring: "\"hi\"", in: textView, equals: palette.syntaxString)
+        XCTAssertColor(atSubstring: "# comment", in: textView, equals: palette.syntaxComment)
+    }
+
+    private func XCTAssertColor(
+        atSubstring substring: String,
+        in textView: NSTextView,
+        equals expectedColor: NSColor,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let text = textView.string as NSString
+        let range = text.range(of: substring)
+        XCTAssertNotEqual(range.location, NSNotFound, file: file, line: line)
+
+        guard range.location != NSNotFound,
+              let actualColor = textView.textStorage?.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? NSColor else {
+            XCTFail("Missing foreground color for \(substring)", file: file, line: line)
+            return
+        }
+
+        XCTAssertTrue(
+            actualColor.isEqual(expectedColor),
+            "Expected \(substring) to use \(expectedColor), got \(actualColor)",
+            file: file,
+            line: line
+        )
+    }
+}
+
+@MainActor
+private final class CountingEditorHighlighter: EditorHighlighting {
+    private(set) var applyCount = 0
+    private(set) var incrementalApplyCount = 0
+    private(set) var lastChangedRange: NSRange?
+
+    func setPalette(_ newPalette: EditorPalette) {}
+
+    func apply(to textView: NSTextView) {
+        applyCount += 1
+    }
+
+    func apply(to textView: NSTextView, changedRange: NSRange) {
+        incrementalApplyCount += 1
+        lastChangedRange = changedRange
     }
 }

--- a/apps/macos/ClearanceTests/Models/DocumentSessionTests.swift
+++ b/apps/macos/ClearanceTests/Models/DocumentSessionTests.swift
@@ -46,6 +46,19 @@ final class DocumentSessionTests: XCTestCase {
         XCTAssertTrue(session.hasExternalChanges)
     }
 
+    func testDiskChangeMatchingCurrentContentDoesNotTriggerExternalChangeAlert() throws {
+        let fileURL = try makeTempMarkdown(contents: "hello")
+        let session = try DocumentSession(url: fileURL, autosaveDelay: 1.0)
+
+        session.content = "local edit"
+        try "local edit".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        session.checkForExternalChanges()
+
+        XCTAssertFalse(session.hasExternalChanges)
+        XCTAssertFalse(session.isDirty)
+    }
+
     func testReloadFromDiskUpdatesSessionAndClearsExternalFlag() throws {
         let fileURL = try makeTempMarkdown(contents: "hello")
         let session = try DocumentSession(url: fileURL, autosaveDelay: 1.0)

--- a/apps/macos/ClearanceTests/Models/FrontmatterParserTests.swift
+++ b/apps/macos/ClearanceTests/Models/FrontmatterParserTests.swift
@@ -86,4 +86,19 @@ final class FrontmatterParserTests: XCTestCase {
 
         XCTAssertEqual(parsed.headings.map(\.title), ["Keep", "Also Keep"])
     }
+
+    func testWorkspaceParserSkipsFrontmatterAndOutlineWorkWhileEditing() {
+        let markdown = """
+        ---
+        title: Sample
+        ---
+        # Heading
+        """
+
+        let parsed = WorkspaceParsedDocumentBuilder().parsedDocument(for: markdown, mode: .edit)
+
+        XCTAssertEqual(parsed.body, markdown)
+        XCTAssertTrue(parsed.flattenedFrontmatter.isEmpty)
+        XCTAssertTrue(parsed.headings.isEmpty)
+    }
 }

--- a/apps/macos/ClearanceTests/SmokeTests.swift
+++ b/apps/macos/ClearanceTests/SmokeTests.swift
@@ -4,4 +4,17 @@ final class SmokeTests: XCTestCase {
     func testProjectCompiles() {
         XCTAssertTrue(true)
     }
+
+    func testMainWorkspaceSceneUsesSingleWindow() throws {
+        let testsURL = URL(fileURLWithPath: #filePath)
+        let projectRoot = testsURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let appSourceURL = projectRoot
+            .appendingPathComponent("Clearance/App/ClearanceApp.swift")
+        let source = try String(contentsOf: appSourceURL, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("Window(\"Clearance\", id: \"main\")"))
+        XCTAssertFalse(source.contains("WindowGroup"))
+    }
 }

--- a/docs/plans/2026-03-04-clearance-v1-implementation.md
+++ b/docs/plans/2026-03-04-clearance-v1-implementation.md
@@ -331,3 +331,7 @@ Add quick start and known limitations in `README.md`.
 git add README.md
 git commit -m "docs: add clearance v1 usage and verification notes"
 ```
+
+## Future Work
+
+- Add richer color coding to the editor, including clearer Markdown token colors and code-fence-aware syntax colors, while preserving fast typing performance on large documents.


### PR DESCRIPTION
I have been using Clearance as a lightweight Markdown viewer/editor and noticed that editing could become laggy on larger documents, especially while typing near the end of a file. I made these changes for my own local use and wanted to share them upstream in case they are useful.

## Summary

- Avoids reparsing frontmatter/headings while the editor is in edit mode.
- Reworks editor highlighting so normal typing uses incremental highlighting instead of full-document restyling.
- Preserves scroll position while highlighting so the editor does not jump or blink during edits.
- Adds Markdown/frontmatter/code-fence syntax coloring, including YAML frontmatter and Python fenced code.
- Suppresses false external-change alerts when the file on disk already matches the current editor contents.
- Uses a single main app window so opening another Markdown file from Finder routes into the existing Clearance window instead of creating another main window.

## Notes

I tried to keep this focused on editor responsiveness and small macOS behavior fixes. The app still supports explicit pop-out windows through the existing pop-out flow.

## Test Plan

- `xcodebuild test -project apps/macos/Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS'`
  - 177 tests, 0 failures
- `xcodebuild -project apps/macos/Clearance.xcodeproj -scheme Clearance -configuration Release -destination 'platform=macOS' build`
  - Build succeeded

Xcode printed a local CoreSimulator version warning on this Mac, but the macOS test suite and Release build completed successfully.