### PR TITLE
Clarify macOS download instructions

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -8,8 +8,8 @@ For developer setup, build, release, and CI details, see [docs/DEVELOPMENT.md](d
 
 ## Install
 
-1. Download the latest release from GitHub.
-2. Open the `.dmg` (or `.zip`) and move `Clearance.app` into `Applications`.
+1. Download the latest macOS app from [GitHub Releases](https://github.com/prime-radiant-inc/clearance/releases/latest).
+2. Open the downloaded `.zip` file and move `Clearance.app` into `Applications`.
 3. Launch Clearance and open a Markdown file.
 
 ## What You Can Do


### PR DESCRIPTION
## Summary

- Replace the macOS README's vague "Download the latest release from GitHub" instruction with a link to GitHub Releases.

## Why

The root README tells users that the shipping app lives in `apps/macos/README.md`, but that install section did not include a direct release link. This makes the install page stop short of the download destination it asks users to find.

## Validation

- Ran `git diff --check`.
