### PR TITLE
Fix/single dollar math delimiter

### DIFF
--- a/apps/macos/Clearance/Views/Render/RenderedHTMLBuilder.swift
+++ b/apps/macos/Clearance/Views/Render/RenderedHTMLBuilder.swift
@@ -674,7 +674,6 @@ struct RenderedHTMLBuilder {
               window.renderMathInElement(document.body, {
                 delimiters: [
                   { left: '$$', right: '$$', display: true },
-                  { left: '$', right: '$', display: false },
                   { left: '\\\\(', right: '\\\\)', display: false },
                   { left: '\\\\[', right: '\\\\]', display: true }
                 ],

--- a/apps/macos/ClearanceTests/Render/RenderedHTMLBuilderTests.swift
+++ b/apps/macos/ClearanceTests/Render/RenderedHTMLBuilderTests.swift
@@ -655,6 +655,11 @@ final class RenderedHTMLBuilderTests: XCTestCase {
             html.contains("left: '$', right: '$'"),
             "Single-$ delimiter must not be present; it corrupts prose with currency amounts"
         )
+        // The dollar amounts must appear as literal text in the HTML output.
+        XCTAssertTrue(
+            html.contains("$23 billion"),
+            "Currency amounts must appear as literal text in the rendered HTML"
+        )
     }
 
     func testDoubleDoublesDollarDelimiterIsRetained() {

--- a/apps/macos/ClearanceTests/Render/RenderedHTMLBuilderTests.swift
+++ b/apps/macos/ClearanceTests/Render/RenderedHTMLBuilderTests.swift
@@ -640,6 +640,36 @@ final class RenderedHTMLBuilderTests: XCTestCase {
         XCTAssertTrue(html.contains("sha256-"))
     }
 
+    func testCurrencyAmountsAreNotRenderedAsMath() {
+        // Prose containing two dollar signs must not be consumed as inline math.
+        // Before the fix, "from $23 billion to $14 billion" would be italicised
+        // and the dollar signs would vanish because KaTeX auto-render treated
+        // $...$ as an inline math delimiter.
+        let body = "The budget proposes a nearly 40 percent reduction — from $23 billion to roughly $14 billion — in the National Park Service's maintenance budget."
+        let document = ParsedMarkdownDocument(body: body, flattenedFrontmatter: [:])
+
+        let html = RenderedHTMLBuilder().build(document: document)
+
+        // The single-$ delimiter must not appear in the KaTeX auto-render config.
+        XCTAssertFalse(
+            html.contains("left: '$', right: '$'"),
+            "Single-$ delimiter must not be present; it corrupts prose with currency amounts"
+        )
+    }
+
+    func testDoubleDoublesDollarDelimiterIsRetained() {
+        // Display-math via $$...$$ must still work after removing the single-$ delimiter.
+        let body = "Display math: $$E = mc^2$$"
+        let document = ParsedMarkdownDocument(body: body, flattenedFrontmatter: [:])
+
+        let html = RenderedHTMLBuilder().build(document: document)
+
+        XCTAssertTrue(
+            html.contains("left: '$$', right: '$$'"),
+            "Double-dollar display-math delimiter must still be present"
+        )
+    }
+
     func testGraphvizSVGScalesToAvailableWidth() {
         let body = """
         ```dot

--- a/packages/demo-corpus/01-rich-rendering.md
+++ b/packages/demo-corpus/01-rich-rendering.md
@@ -7,7 +7,7 @@ category: rendering
 
 This document exercises math, LaTeX, and Mermaid rendering.
 
-Inline math example: $E = mc^2$ and $\alpha + \beta = \gamma$.
+Inline math example: \(E = mc^2\) and \(\alpha + \beta = \gamma\).
 
 Display math example:
 


### PR DESCRIPTION
## Problem

Prose containing multiple dollar signs was rendered incorrectly. Example from issue #45:

> "from $23 billion to roughly $14 billion"

Rendered as: *23billiontoroughly* 14 billion — dollar signs vanished, content italicised as LaTeX.

## Root cause

`RenderedHTMLBuilder.swift` passed `{ left: '$', right: '$', display: false }` to KaTeX `renderMathInElement()`, causing any two dollar signs on the same line to be treated as inline math delimiters.

## Fix

Remove `{ left: '$', right: '$', display: false }` from the delimiter list. One line deleted.

Inline math is still fully supported via `\(...\)` and `\[...\]`.
Display math still works via `$$...$$`.
Fenced ` ```latex ` blocks are unaffected.

## Tests

- `testCurrencyAmountsAreNotRenderedAsMath` — verifies single-`$` config is absent AND that `$23 billion` appears as literal text in the output
- `testDoubleDoublesDollarDelimiterIsRetained` — verifies `$$` display math config is still present

Also updated `demo-corpus/01-rich-rendering.md` to use `\(...\)` for inline math examples.

Closes #45