### PR TITLE
Add local CLI install option

### DIFF
--- a/apps/macos/Clearance/Services/ClearanceCommandLineToolInstaller.swift
+++ b/apps/macos/Clearance/Services/ClearanceCommandLineToolInstaller.swift
@@ -1,9 +1,29 @@
 import AppKit
 import Foundation
 
+enum ClearanceCommandLineToolInstallLocation: String, CaseIterable, Identifiable {
+    case systemBin
+    case localBin
+
+    var id: String {
+        rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .systemBin:
+            return "/usr/local/bin"
+        case .localBin:
+            return "~/.local/bin"
+        }
+    }
+}
+
 enum ClearanceCommandLineToolInstallerError: LocalizedError, Equatable {
     case bundledInstallerNotFound
     case installerLaunchFailed(URL)
+    case bundledHelperNotFound
+    case localInstallFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -11,6 +31,10 @@ enum ClearanceCommandLineToolInstallerError: LocalizedError, Equatable {
             return "Bundled command-line installer package not found."
         case .installerLaunchFailed(let url):
             return "Could not open \(url.lastPathComponent) in Installer."
+        case .bundledHelperNotFound:
+            return "Bundled command-line helper not found."
+        case .localInstallFailed(let reason):
+            return "Could not install command-line helper: \(reason)"
         }
     }
 }
@@ -25,12 +49,33 @@ struct ClearanceCommandLineToolInstaller {
     static let packageResourceName = "ClearanceCLIInstaller"
     static let packageExtension = "pkg"
     static let packageFileName = "\(packageResourceName).\(packageExtension)"
+    static let defaultLocalBinURL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".local/bin", isDirectory: true)
 
     static func installerPackageURL(in bundle: Bundle = .main) -> URL? {
         bundle.url(
             forResource: packageResourceName,
             withExtension: packageExtension
         )
+    }
+
+    static func install(
+        to location: ClearanceCommandLineToolInstallLocation,
+        bundle: Bundle = .main,
+        workspace: WorkspaceOpening = NSWorkspace.shared,
+        localBinURL: URL = defaultLocalBinURL,
+        fileManager: FileManager = .default
+    ) throws {
+        switch location {
+        case .systemBin:
+            try install(bundle: bundle, workspace: workspace)
+        case .localBin:
+            try installLocalBin(
+                bundle: bundle,
+                localBinURL: localBinURL,
+                fileManager: fileManager
+            )
+        }
     }
 
     static func install(
@@ -44,5 +89,43 @@ struct ClearanceCommandLineToolInstaller {
         guard workspace.open(packageURL) else {
             throw ClearanceCommandLineToolInstallerError.installerLaunchFailed(packageURL)
         }
+    }
+
+    private static func installLocalBin(
+        bundle: Bundle,
+        localBinURL: URL,
+        fileManager: FileManager
+    ) throws {
+        guard let helperURL = ClearanceCommandLineTool.helperExecutableURL(in: bundle) else {
+            throw ClearanceCommandLineToolInstallerError.bundledHelperNotFound
+        }
+
+        let installedURL = localBinURL.appendingPathComponent(ClearanceCommandLineTool.name)
+
+        do {
+            try fileManager.createDirectory(
+                at: localBinURL,
+                withIntermediateDirectories: true
+            )
+
+            if fileManager.fileExists(atPath: installedURL.path)
+                || fileManager.isSymbolicLink(at: installedURL) {
+                try fileManager.removeItem(at: installedURL)
+            }
+
+            try fileManager.copyItem(at: helperURL, to: installedURL)
+            try fileManager.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: installedURL.path
+            )
+        } catch {
+            throw ClearanceCommandLineToolInstallerError.localInstallFailed(error.localizedDescription)
+        }
+    }
+}
+
+private extension FileManager {
+    func isSymbolicLink(at url: URL) -> Bool {
+        (try? attributesOfItem(atPath: url.path)[.type] as? FileAttributeType) == .typeSymbolicLink
     }
 }

--- a/apps/macos/Clearance/Views/SettingsView.swift
+++ b/apps/macos/Clearance/Views/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @ObservedObject var settings: AppSettings
+    @State private var commandLineToolInstallLocation: ClearanceCommandLineToolInstallLocation = .systemBin
     @State private var commandLineToolStatus: String?
     @State private var commandLineToolStatusIsError = false
 
@@ -41,11 +42,18 @@ struct SettingsView: View {
             Divider()
 
             VStack(alignment: .leading, spacing: 8) {
+                Picker("Install Location", selection: $commandLineToolInstallLocation) {
+                    ForEach(ClearanceCommandLineToolInstallLocation.allCases) { location in
+                        Text(location.title).tag(location)
+                    }
+                }
+                .pickerStyle(.segmented)
+
                 Button("Install Command-Line Tool") {
                     installCommandLineTool()
                 }
 
-                Text("Adds `clearance` to `/usr/local/bin` so Terminal can open files and folders in Clearance. That location may require admin privileges on some Macs.")
+                Text(commandLineToolInstallDescription)
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
@@ -60,14 +68,32 @@ struct SettingsView: View {
         .frame(width: 440)
     }
 
+    private var commandLineToolInstallDescription: String {
+        switch commandLineToolInstallLocation {
+        case .systemBin:
+            return "Adds `clearance` to `/usr/local/bin` using the bundled installer package. This may require admin privileges."
+        case .localBin:
+            return "Adds `clearance` to `~/.local/bin` for this user without admin privileges. Make sure `~/.local/bin` is on your shell PATH."
+        }
+    }
+
     private func installCommandLineTool() {
         do {
-            try ClearanceCommandLineToolInstaller.install()
-            commandLineToolStatus = "Opened the command-line installer package in Installer."
+            try ClearanceCommandLineToolInstaller.install(to: commandLineToolInstallLocation)
+            commandLineToolStatus = commandLineToolInstallSuccessMessage
             commandLineToolStatusIsError = false
         } catch {
             commandLineToolStatus = error.localizedDescription
             commandLineToolStatusIsError = true
+        }
+    }
+
+    private var commandLineToolInstallSuccessMessage: String {
+        switch commandLineToolInstallLocation {
+        case .systemBin:
+            return "Opened the command-line installer package in Installer."
+        case .localBin:
+            return "Installed clearance in ~/.local/bin."
         }
     }
 }

--- a/apps/macos/ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift
+++ b/apps/macos/ClearanceTests/Services/ClearanceCommandLineInstallerTests.swift
@@ -53,16 +53,88 @@ final class ClearanceCommandLineInstallerTests: XCTestCase {
         }
     }
 
-    private func makeBundle(includesPackage: Bool) throws -> URL {
+    func testInstallToLocalBinCopiesBundledHelper() throws {
+        let bundleURL = try makeBundle(includesPackage: false, includesHelper: true)
+        let bundle = try XCTUnwrap(Bundle(url: bundleURL))
+        let localBinURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent(".local/bin", isDirectory: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: localBinURL.deletingLastPathComponent().deletingLastPathComponent())
+        }
+
+        try ClearanceCommandLineToolInstaller.install(
+            to: .localBin,
+            bundle: bundle,
+            localBinURL: localBinURL
+        )
+
+        let installedURL = localBinURL.appendingPathComponent(ClearanceCommandLineTool.name)
+        let installedData = try Data(contentsOf: installedURL)
+        XCTAssertEqual(installedData, Data("helper".utf8))
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: installedURL.path)
+        let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+        XCTAssertEqual(permissions.intValue & 0o111, 0o111)
+
+        let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: installedURL.path)
+        XCTAssertNil(destination)
+    }
+
+    func testInstallToLocalBinReplacesExistingFile() throws {
+        let bundleURL = try makeBundle(includesPackage: false, includesHelper: true)
+        let bundle = try XCTUnwrap(Bundle(url: bundleURL))
+        let localBinURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: localBinURL, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: localBinURL)
+        }
+
+        let installedURL = localBinURL.appendingPathComponent(ClearanceCommandLineTool.name)
+        try Data("old helper".utf8).write(to: installedURL)
+
+        try ClearanceCommandLineToolInstaller.install(
+            to: .localBin,
+            bundle: bundle,
+            localBinURL: localBinURL
+        )
+
+        XCTAssertEqual(try Data(contentsOf: installedURL), Data("helper".utf8))
+    }
+
+    func testInstallToLocalBinReportsMissingHelper() throws {
+        let bundleURL = try makeBundle(includesPackage: false, includesHelper: false)
+        let bundle = try XCTUnwrap(Bundle(url: bundleURL))
+        let localBinURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+
+        XCTAssertThrowsError(
+            try ClearanceCommandLineToolInstaller.install(
+                to: .localBin,
+                bundle: bundle,
+                localBinURL: localBinURL
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? ClearanceCommandLineToolInstallerError,
+                .bundledHelperNotFound
+            )
+        }
+    }
+
+    private func makeBundle(includesPackage: Bool, includesHelper: Bool = false) throws -> URL {
         let rootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("app")
         let contentsURL = rootURL.appendingPathComponent("Contents", isDirectory: true)
         let resourcesURL = contentsURL.appendingPathComponent("Resources", isDirectory: true)
         let macOSURL = contentsURL.appendingPathComponent("MacOS", isDirectory: true)
+        let helpersURL = contentsURL.appendingPathComponent("Helpers", isDirectory: true)
 
         try FileManager.default.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: macOSURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: helpersURL, withIntermediateDirectories: true)
 
         let executableURL = macOSURL.appendingPathComponent("Clearance")
         try Data().write(to: executableURL)
@@ -87,6 +159,15 @@ final class ClearanceCommandLineInstallerTests: XCTestCase {
                 "\(ClearanceCommandLineToolInstaller.packageFileName)"
             )
             try Data().write(to: packageURL)
+        }
+
+        if includesHelper {
+            let helperURL = helpersURL.appendingPathComponent(ClearanceCommandLineTool.name)
+            try Data("helper".utf8).write(to: helperURL)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: helperURL.path
+            )
         }
 
         return rootURL

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -9,7 +9,7 @@ For developer setup, build, release, and CI details, see [docs/DEVELOPMENT.md](d
 ## Install
 
 1. Download the latest macOS app from [GitHub Releases](https://github.com/prime-radiant-inc/clearance/releases/latest).
-2. Open the downloaded `.zip` file and move `Clearance.app` into `Applications`.
+2. Open the downloaded `.dmg` and drag `Clearance.app` into Applications, or unzip the `.zip` build and move `Clearance.app` yourself.
 3. Launch Clearance and open a Markdown file.
 
 ## What You Can Do


### PR DESCRIPTION
## Summary

- Add a Settings install-location picker for the command-line tool.
- Keep the existing /usr/local/bin package installer path.
- Add a per-user ~/.local/bin install path that copies the bundled helper as a standalone executable instead of symlinking into Clearance.app.
- Correct the macOS README install wording after #49 so the DMG is the default install path while the ZIP remains documented.

Implements the feature requested in #31 using the current apps/macos layout.

## Verification

- Confirmed new installer tests failed first because .localBin, install(to:), and bundledHelperNotFound did not exist.
- xcodebuild -quiet test -project apps/macos/Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceCommandLineInstallerTests
- git diff --check
- xcodebuild -quiet test -project apps/macos/Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS'
- Unsigned Release build with CODE_SIGNING_ALLOWED=NO and version overrides; verified Contents/Helpers/clearance exists and is executable.
