### PR TITLE
Add in-app help system

### DIFF
--- a/apps/macos/Clearance/App/AppDelegate.swift
+++ b/apps/macos/Clearance/App/AppDelegate.swift
@@ -36,4 +36,5 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 extension Notification.Name {
     static let clearanceOpenURLs = Notification.Name("clearance.openURLs")
     static let clearanceOpenReadOnlyMarkdownURL = Notification.Name("clearance.openReadOnlyMarkdownURL")
+    static let clearanceShowHelp = Notification.Name("clearance.showHelp")
 }

--- a/apps/macos/Clearance/App/ClearanceApp.swift
+++ b/apps/macos/Clearance/App/ClearanceApp.swift
@@ -10,6 +10,7 @@ enum ExternalEventRouting {
 struct ClearanceApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var appSettings: AppSettings
+    @StateObject private var helpViewModel: HelpViewModel
     @State private var hasCheckedForUpdatedReleaseNotes = false
     private let sparkleUpdateController = SparkleUpdateController()
     private let popoutWindowController = PopoutWindowController()
@@ -17,6 +18,7 @@ struct ClearanceApp: App {
     init() {
         LegacyDefaultsMigration().migrateIfNeeded()
         _appSettings = StateObject(wrappedValue: AppSettings())
+        _helpViewModel = StateObject(wrappedValue: HelpViewModel(topics: HelpCatalog().topics()))
     }
 
     var body: some Scene {
@@ -46,6 +48,12 @@ struct ClearanceApp: App {
             SettingsView(settings: appSettings)
                 .clearancePreferredAppearance(appSettings.appearance)
         }
+
+        Window("Clearance Help", id: "help") {
+            HelpWindowView(viewModel: helpViewModel, appSettings: appSettings)
+                .clearancePreferredAppearance(appSettings.appearance)
+        }
+        .defaultSize(width: 900, height: 680)
     }
 
     private func showUpdatedReleaseNotesIfNeeded() {
@@ -225,6 +233,13 @@ private struct ClearanceCommands: Commands {
     }
 
     var body: some Commands {
+        CommandGroup(replacing: .help) {
+            // No key equivalent: SwiftUI does not honor keyboardShortcut on Help-menu items.
+            Button("Clearance Help") {
+                NotificationCenter.default.post(name: .clearanceShowHelp, object: nil)
+            }
+        }
+
         CommandGroup(replacing: .appInfo) {
             Button("About Clearance") {
                 showAboutPanel()

--- a/apps/macos/Clearance/Models/HelpTopic.swift
+++ b/apps/macos/Clearance/Models/HelpTopic.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct HelpTopic: Identifiable, Equatable {
+    let slug: String        // filename without extension, e.g. "opening-files"
+    let title: String       // from frontmatter `title`
+    let order: Int          // from frontmatter `order`
+    let fileURL: URL        // standardized file URL of the bundled topic
+    let body: String        // parsed body (frontmatter stripped), for search
+
+    var id: String { slug }
+
+    /// Document used for rendering: the body with NO frontmatter, so the shared
+    /// RenderedHTMLBuilder does not emit a visible "Metadata" box for the
+    /// authoring-only title/order keys.
+    var renderDocument: ParsedMarkdownDocument {
+        ParsedMarkdownDocument(body: body, flattenedFrontmatter: [:])
+    }
+}

--- a/apps/macos/Clearance/Resources/Help/01-welcome.md
+++ b/apps/macos/Clearance/Resources/Help/01-welcome.md
@@ -1,0 +1,16 @@
+---
+title: Welcome to Clearance
+order: 1
+---
+
+# Welcome to Clearance
+
+Clearance is a native macOS app for reading and editing Markdown and plain-text files.
+
+Clearance shows every document in two ways: In **View mode**, Clearance renders your Markdown into a clean, formatted page. In **Edit mode**, you work directly with the Markdown text, with syntax highlighting to keep things readable. You can switch between them whenever you like.
+
+To get started, open a file. Choose **File** > **Open…** (or press ⌘O), then choose a Markdown or text file; by default, it opens in **View mode**, ready to read. See [Opening Files](02-opening-files.md) for the other ways to open documents.
+
+When you're ready to make changes, head to [Viewing and Editing](03-viewing-and-editing.md). And if you'd like to move quickly, [Keyboard Shortcuts](12-keyboard-shortcuts.md) gathers the shortcuts in one place.
+
+Questions and conversation about Clearance happen in the [Prime Radiant community on Discord](https://discord.com/invite/Jd8Vphy9jq). The project lives on [GitHub](https://github.com/prime-radiant-inc/clearance).

--- a/apps/macos/Clearance/Resources/Help/02-opening-files.md
+++ b/apps/macos/Clearance/Resources/Help/02-opening-files.md
@@ -1,0 +1,14 @@
+---
+title: Opening Files
+order: 2
+---
+
+# Opening Files
+
+To open a document, choose **File** > **Open…** or press ⌘O, then pick a file. Clearance opens Markdown (`.md`) and plain-text (`.txt`) files.
+
+The **Recent Files** sidebar keeps the documents you've opened lately. They're grouped by recency, and each entry shows the file's name and the folder it lives in, so you can tell similarly named files apart at a glance. Click any entry to reopen it.
+
+You may also drag a file from the Finder. Drop it onto the **Recent Files** sidebar to open it in the current window, or onto the document area to open it in a new window.
+
+Sometimes you'll want the current document in its own window — to compare two parts of it, perhaps. Choose **Open In New Window** or press ⇧⌘O, and a fresh window appears with the same document.

--- a/apps/macos/Clearance/Resources/Help/03-viewing-and-editing.md
+++ b/apps/macos/Clearance/Resources/Help/03-viewing-and-editing.md
@@ -1,0 +1,16 @@
+---
+title: Viewing and Editing
+order: 3
+---
+
+# Viewing and Editing
+
+Clearance shows your document two ways, and you choose which at any moment.
+
+Switch to **View mode** with ⌘1; the document appears formatted and rendered, the way it's meant to be read. To see everything **View mode** can show, visit [Rich Markdown Rendering](05-rich-rendering.md).
+
+Switch to **Edit mode** with ⌘2; the document becomes editable plain Markdown, with syntax highlighting to keep the structure clear as you type. New to Markdown? See [Writing in Markdown](04-writing-in-markdown.md) for the syntax.
+
+There's no Save command — your edits save automatically as you go.
+
+Undo with ⌘Z, and Redo with ⇧⌘Z.

--- a/apps/macos/Clearance/Resources/Help/04-writing-in-markdown.md
+++ b/apps/macos/Clearance/Resources/Help/04-writing-in-markdown.md
@@ -1,0 +1,88 @@
+---
+title: Writing in Markdown
+order: 4
+---
+
+# Writing in Markdown
+
+In **Edit mode**, you write Markdown — plain text with a few additions for formatting. In **View mode**, Clearance shows it formatted. Here's the syntax you'll reach for most.
+
+## Headings
+
+Start a line with one to six `#` characters and a space. More hashes means a smaller heading, from `#` down to `######`.
+
+```
+# Title
+## Section
+### Subsection
+```
+
+## Emphasis
+
+Wrap text in `**bold**` for bold, `*italic*` for italic, and `~~strikethrough~~` for strikethrough.
+
+## Line breaks
+
+A blank line starts a new paragraph. To force a line break within a paragraph, end a line with two spaces, or with a backslash `\`.
+
+## Lists
+
+Start each item with `-` and a space for an unordered list:
+
+```
+- First
+- Second
+```
+
+Use `1.` (and so on) for an ordered list:
+
+```
+1. First
+2. Second
+```
+
+## Links
+
+Write the link text in square brackets, then the address in parentheses: `[text](https://example.com)`. To link to another file, point at its path instead: `[the welcome topic](01-welcome.md)`.
+
+## Images
+
+To insert an image, write a link with a `!` in front: `![description](path/to/image.png)`. The text in brackets is the image's alternative text, describing it for anyone who can't see it.
+
+## Code
+
+For a few words of code, wrap them in single backticks: `` `code` ``. For a whole block, fence it between lines of triple backticks. Name the language after the opening fence to get syntax highlighting:
+
+````
+```swift
+let greeting = "Hello"
+```
+````
+
+Fenced code blocks get syntax highlighting for common languages — Swift, JavaScript/TypeScript, JSON, shell, and YAML — with basic highlighting for others.
+
+## Blockquotes
+
+Start a line with `>` to quote it:
+
+```
+> A quoted line.
+```
+
+## Horizontal rule
+
+Put `---` on its own line to draw a divider across the page.
+
+## Tables
+
+Separate columns with pipes `|`, then add a `|---|---|` row to mark the header:
+
+```
+| Name  | Role   |
+|-------|--------|
+| Ada   | Author |
+```
+
+To align a column, add colons to its cell in the separator row: `:---` for left, `:---:` for center, and `---:` for right.
+
+When you're ready for more, [Rich Markdown Rendering](05-rich-rendering.md) covers the richer features Clearance renders — math, diagrams, task lists, and frontmatter.

--- a/apps/macos/Clearance/Resources/Help/05-rich-rendering.md
+++ b/apps/macos/Clearance/Resources/Help/05-rich-rendering.md
@@ -1,0 +1,27 @@
+---
+title: Rich Markdown Rendering
+order: 5
+---
+
+# Rich Markdown Rendering
+
+Clearance opens both plain-text and Markdown files, and in **View mode** it renders the full range of Markdown. Here's what you'll see formatted on the page:
+
+- Standard Markdown: headings, lists, links, block quotes, and inline code.
+- YAML frontmatter, shown as a tidy summary at the top of the document.
+- GitHub-style tables, with column alignment respected.
+- Task lists, where `- [ ]` and `- [x]` become checkboxes.
+- Fenced code blocks, with syntax highlighting for the language you name.
+- Math, typeset with KaTeX.
+- Diagrams, drawn with Mermaid and Graphviz.
+
+For the basics of writing Markdown, see [Writing in Markdown](04-writing-in-markdown.md).
+
+For math, Clearance uses KaTeX: write a displayed equation with `$$…$$`, write inline math with `\(…\)`, or put an equation in a ```` ```math ```` code block. For the full list of what KaTeX understands, see the [KaTeX supported functions](https://katex.org/docs/supported.html).
+
+For diagrams, Clearance draws two kinds:
+
+- [Mermaid](https://mermaid.js.org/), in a ```` ```mermaid ```` block.
+- [Graphviz](https://graphviz.org/), in a ```` ```dot ```` or ```` ```graphviz ```` block.
+
+Click any diagram to expand it; it opens in a larger overlay so you can see the detail.

--- a/apps/macos/Clearance/Resources/Help/06-links-and-navigation.md
+++ b/apps/macos/Clearance/Resources/Help/06-links-and-navigation.md
@@ -1,0 +1,12 @@
+---
+title: Links, Navigation, and the Outline
+order: 6
+---
+
+# Links, Navigation, and the Outline
+
+In **View mode**, the links in your document are live. Click a link to a local Markdown or text file, and that document opens right inside Clearance. Click a web link, and it opens in your browser.
+
+As you follow links from one document to the next, Clearance remembers your trail. Press ⌘[ to go Back to where you came from, and ⌘] to go Forward again.
+
+For longer documents, the **Outline** on the right lists the document's headings. Click any heading to jump straight to it. In **View mode**, the **Outline** appears when the document has headings. You can show or hide it with **Show/Hide Outline**.

--- a/apps/macos/Clearance/Resources/Help/07-finding-text.md
+++ b/apps/macos/Clearance/Resources/Help/07-finding-text.md
@@ -1,0 +1,12 @@
+---
+title: Finding Text
+order: 7
+---
+
+# Finding Text
+
+To search the current document, press ⌘F to **Find**. Type what you're looking for, and Clearance highlights the matches.
+
+To step back to the previous match, press ⇧⌘F for **Find Previous**.
+
+In **Edit mode**, the Find panel (⌘F) can also replace text — switch it to its **Replace** tab to swap matches for new text.

--- a/apps/macos/Clearance/Resources/Help/08-printing.md
+++ b/apps/macos/Clearance/Resources/Help/08-printing.md
@@ -1,0 +1,10 @@
+---
+title: Printing
+order: 8
+---
+
+# Printing
+
+To print your document, choose **File** > **Print…** or press ⌘P.
+
+Clearance always prints the formatted, **View mode** version of the document — the same clean layout you see on screen, not the raw Markdown. For a plain-text file, that's essentially your text laid out in paragraphs; note that single line breaks within a paragraph may merge into one flowing line.

--- a/apps/macos/Clearance/Resources/Help/09-settings.md
+++ b/apps/macos/Clearance/Resources/Help/09-settings.md
@@ -1,0 +1,31 @@
+---
+title: Settings
+order: 9
+---
+
+# Settings
+
+Open the Settings dialog with **Clearance** > **Settings…** (⌘,). It holds three preferences and a button to install the command-line tool.
+
+## Default Open Mode
+
+This sets the mode newly opened files start in — **View** or **Edit**. Choose **View** to land on the formatted page, or **Edit** to start in the Markdown text. You can always switch once a document is open; see [Viewing and Editing](03-viewing-and-editing.md).
+
+## Theme
+
+Pick the look of the rendered page:
+
+- **Apple** — neutral tones with system-accent links.
+- **Classic Blue** — the original indigo-heavy Clearance palette.
+
+## Appearance
+
+Choose **Light**, **Dark**, or **System** to follow whatever your Mac is set to.
+
+## Command-Line Tool
+
+The dialog also has a button to install the `clearance` command, which opens files in Clearance from the Terminal. For install locations and usage, see [Command-Line Tool](10-command-line-tool.md).
+
+## Text Size
+
+Text size isn't set in the Settings dialog. Adjust it from the **View** menu: **Zoom In** (⌘+), **Zoom Out** (⌘-), and **Actual Size** (⌘0). These apply to the rendered **View**.

--- a/apps/macos/Clearance/Resources/Help/10-command-line-tool.md
+++ b/apps/macos/Clearance/Resources/Help/10-command-line-tool.md
@@ -1,0 +1,23 @@
+---
+title: Command-Line Tool
+order: 10
+---
+
+# Command-Line Tool
+
+Clearance can install a `clearance` command you run in the Terminal to open files in the app. Pass it one or more paths:
+
+```
+clearance notes.md
+```
+
+Clearance opens each file you name. If a path doesn't exist yet, Clearance creates a new Markdown file there first, then opens it.
+
+## Installing it
+
+From **Clearance** > **Settings…**, choose an install location and click the install button. There are two choices:
+
+- `/usr/local/bin` — installs through the bundled installer package, which opens in the Installer app. This location may require administrator access.
+- `~/.local/bin` — installs to your home folder without administrator access. Make sure `~/.local/bin` is on your shell's `PATH` so the `clearance` command is found.
+
+You'll find this in [Settings](09-settings.md).

--- a/apps/macos/Clearance/Resources/Help/11-updates.md
+++ b/apps/macos/Clearance/Resources/Help/11-updates.md
@@ -1,0 +1,10 @@
+---
+title: Updates
+order: 11
+---
+
+# Updates
+
+Clearance has two update commands in the menu: **Check for Updates…** and **Show Release Notes**.
+
+Choose **Check for Updates…** and Clearance looks for a newer version and offers to install one if it's available. If your build isn't set up for updates, **Check for Updates…** is grayed out — but you can always read what's new with **Show Release Notes**.

--- a/apps/macos/Clearance/Resources/Help/12-keyboard-shortcuts.md
+++ b/apps/macos/Clearance/Resources/Help/12-keyboard-shortcuts.md
@@ -1,0 +1,27 @@
+---
+title: Keyboard Shortcuts
+order: 12
+---
+
+# Keyboard Shortcuts
+
+Here are the shortcuts you'll reach for most often.
+
+| Action | Shortcut |
+| --- | --- |
+| New | ⌘N |
+| Open | ⌘O |
+| Open In New Window | ⇧⌘O |
+| Print | ⌘P |
+| Undo | ⌘Z |
+| Redo | ⇧⌘Z |
+| Back | ⌘[ |
+| Forward | ⌘] |
+| Find | ⌘F |
+| Find Previous | ⇧⌘F |
+| View mode | ⌘1 |
+| Edit mode | ⌘2 |
+| Zoom In | ⌘+ |
+| Zoom Out | ⌘- |
+| Actual Size | ⌘0 |
+| Clearance Help | ⌘? |

--- a/apps/macos/Clearance/Services/HelpCatalog.swift
+++ b/apps/macos/Clearance/Services/HelpCatalog.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct HelpCatalog {
+    private let bundle: Bundle
+    private let subdirectory: String
+
+    init(bundle: Bundle = .main, subdirectory: String = "Help") {
+        self.bundle = bundle
+        self.subdirectory = subdirectory
+    }
+
+    /// Bundled help topic file URLs. Requires the Help folder to be bundled as a
+    /// folder reference so `subdirectory:` enumeration works.
+    func topicFileURLs() -> [URL] {
+        bundle.urls(forResourcesWithExtension: "md", subdirectory: subdirectory) ?? []
+    }
+
+    /// Ordered topics from the bundle.
+    func topics() -> [HelpTopic] {
+        HelpCatalog.makeTopics(from: topicFileURLs())
+    }
+
+    /// Pure loader: reads each file, parses frontmatter, returns topics ordered by
+    /// `order` then `title`. Files lacking a non-empty `title` are skipped.
+    static func makeTopics(from urls: [URL], parser: FrontmatterParser = FrontmatterParser()) -> [HelpTopic] {
+        var topics: [HelpTopic] = []
+        for url in urls {
+            guard let content = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            let parsed = parser.parse(markdown: content)
+            guard let title = parsed.flattenedFrontmatter["title"], !title.isEmpty else { continue }
+            let order = parsed.flattenedFrontmatter["order"].flatMap { Int($0) } ?? Int.max
+            let slug = url.deletingPathExtension().lastPathComponent
+            topics.append(
+                HelpTopic(
+                    slug: slug,
+                    title: title,
+                    order: order,
+                    fileURL: url.standardizedFileURL,
+                    body: parsed.body
+                )
+            )
+        }
+        return topics.sorted { ($0.order, $0.title) < ($1.order, $1.title) }
+    }
+}

--- a/apps/macos/Clearance/Services/HelpSearchIndex.swift
+++ b/apps/macos/Clearance/Services/HelpSearchIndex.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+struct HelpSearchResult: Equatable {
+    let topic: HelpTopic
+    let snippet: String
+}
+
+struct HelpSearchIndex {
+    private let topics: [HelpTopic]
+
+    init(topics: [HelpTopic]) {
+        self.topics = topics
+    }
+
+    func search(_ query: String) -> [HelpSearchResult] {
+        let terms = query
+            .lowercased()
+            .split(whereSeparator: { $0.isWhitespace })
+            .map(String.init)
+        guard !terms.isEmpty else { return [] }
+
+        var scored: [(result: HelpSearchResult, score: Int)] = []
+        for topic in topics {
+            let title = topic.title.lowercased()
+            let body = topic.body.lowercased()
+            guard terms.allSatisfy({ title.contains($0) || body.contains($0) }) else { continue }
+
+            let titleHits = terms.filter { title.contains($0) }.count
+            // Score against the lowercased body; the snippet uses the original case for display.
+            let bodyHits = terms.reduce(0) { $0 + body.occurrences(of: $1) }
+            let score = titleHits * 1000 + bodyHits
+            let snippet = HelpSearchIndex.snippet(for: terms, in: topic.body)
+            scored.append((HelpSearchResult(topic: topic, snippet: snippet), score))
+        }
+
+        return scored.sorted { $0.score > $1.score }.map(\.result)
+    }
+
+    private static func snippet(for terms: [String], in body: String) -> String {
+        guard let firstTerm = terms.first,
+              let range = body.range(of: firstTerm, options: .caseInsensitive) else {
+            return String(body.prefix(120))
+        }
+        let start = body.index(range.lowerBound, offsetBy: -40, limitedBy: body.startIndex) ?? body.startIndex
+        let end = body.index(range.upperBound, offsetBy: 80, limitedBy: body.endIndex) ?? body.endIndex
+        return String(body[start..<end]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private extension String {
+    func occurrences(of needle: String) -> Int {
+        guard !needle.isEmpty else { return 0 }
+        var count = 0
+        var searchStart = startIndex
+        while let r = range(of: needle, range: searchStart..<endIndex) {
+            count += 1
+            searchStart = r.upperBound
+        }
+        return count
+    }
+}

--- a/apps/macos/Clearance/ViewModels/HelpViewModel.swift
+++ b/apps/macos/Clearance/ViewModels/HelpViewModel.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+@MainActor
+final class HelpViewModel: ObservableObject {
+    @Published private(set) var topics: [HelpTopic]
+    @Published private(set) var currentTopic: HelpTopic?
+    @Published var searchQuery: String = ""
+    @Published private(set) var results: [HelpSearchResult] = []
+
+    private let index: HelpSearchIndex
+    private var backStack: [HelpTopic] = []
+    private var forwardStack: [HelpTopic] = []
+
+    var canGoBack: Bool { !backStack.isEmpty }
+    var canGoForward: Bool { !forwardStack.isEmpty }
+    var isSearching: Bool { !searchQuery.split(whereSeparator: \.isWhitespace).isEmpty }
+
+    init(topics: [HelpTopic]) {
+        self.topics = topics
+        self.index = HelpSearchIndex(topics: topics)
+        self.currentTopic = topics.first
+    }
+
+    func select(_ topic: HelpTopic) {
+        // Re-selecting the current topic is a deliberate no-op; keeps history clean.
+        guard topic != currentTopic else { return }
+        if let current = currentTopic { backStack.append(current) }
+        forwardStack.removeAll()
+        currentTopic = topic
+    }
+
+    /// Navigates to the topic whose bundled file matches `url`. Returns false (and
+    /// does nothing) for non-file links or files that are not known topics; those
+    /// never reach here in practice — the RenderedMarkdownView Coordinator opens
+    /// web/unknown links externally.
+    @discardableResult
+    func openLink(_ url: URL) -> Bool {
+        guard url.isFileURL else { return false }
+        let target = url.standardizedFileURL.path
+        guard let topic = topics.first(where: { $0.fileURL.path == target }) else { return false }
+        select(topic)
+        return true
+    }
+
+    func goBack() {
+        guard let previous = backStack.popLast() else { return }
+        if let current = currentTopic { forwardStack.append(current) }
+        currentTopic = previous
+    }
+
+    func goForward() {
+        guard let next = forwardStack.popLast() else { return }
+        if let current = currentTopic { backStack.append(current) }
+        currentTopic = next
+    }
+
+    /// Refreshes `results` from the current `searchQuery`. The view calls this when
+    /// the query changes; it is intentionally not auto-bound to `searchQuery`.
+    func runSearch() {
+        results = index.search(searchQuery)
+    }
+}

--- a/apps/macos/Clearance/Views/Help/HelpWindowView.swift
+++ b/apps/macos/Clearance/Views/Help/HelpWindowView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct HelpWindowView: View {
+    @ObservedObject var viewModel: HelpViewModel
+    @ObservedObject var appSettings: AppSettings
+
+    var body: some View {
+        NavigationSplitView {
+            sidebar
+                .frame(minWidth: 220)
+        } detail: {
+            detail
+                .frame(minWidth: 480, minHeight: 360)
+        }
+        .frame(minWidth: 760, minHeight: 480)
+    }
+
+    @ViewBuilder
+    private var sidebar: some View {
+        VStack(spacing: 0) {
+            TextField("Search help", text: $viewModel.searchQuery)
+                .textFieldStyle(.roundedBorder)
+                .padding(8)
+                .onChange(of: viewModel.searchQuery) { _, _ in
+                    viewModel.runSearch()
+                }
+
+            if viewModel.isSearching {
+                List(viewModel.results, id: \.topic.id) { result in
+                    Button {
+                        viewModel.select(result.topic)
+                        viewModel.searchQuery = ""
+                    } label: {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(result.topic.title).font(.headline)
+                            Text(result.snippet)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            } else {
+                List(
+                    viewModel.topics,
+                    selection: Binding(
+                        get: { viewModel.currentTopic?.id },
+                        set: { id in
+                            if let topic = viewModel.topics.first(where: { $0.id == id }) {
+                                viewModel.select(topic)
+                            }
+                        }
+                    )
+                ) { topic in
+                    Text(topic.title)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        if let topic = viewModel.currentTopic {
+            RenderedMarkdownView(
+                document: topic.renderDocument,
+                sourceDocumentURL: topic.fileURL,
+                isRemoteContent: false,
+                allowsLocalFileStaging: false,
+                headingScrollRequest: nil,
+                theme: appSettings.theme,
+                appearance: appSettings.appearance,
+                textScale: appSettings.renderedTextScale,
+                onOpenLinkedDocument: { linkedURL in
+                    viewModel.openLink(linkedURL)
+                }
+            )
+        } else {
+            Text("Help content is unavailable.")
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/apps/macos/Clearance/Views/WorkspaceView.swift
+++ b/apps/macos/Clearance/Views/WorkspaceView.swift
@@ -11,6 +11,7 @@ enum WorkspaceDropPayloadResolver {
 }
 
 struct WorkspaceView: View {
+    @Environment(\.openWindow) private var openWindow
     @ObservedObject private var appSettings: AppSettings
     @StateObject private var viewModel: WorkspaceViewModel
     @StateObject private var interactionState = WorkspaceInteractionState()
@@ -257,6 +258,9 @@ struct WorkspaceView: View {
             }
 
             _ = viewModel.openReadOnlyMarkdown(url: url)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .clearanceShowHelp)) { _ in
+            openWindow(id: "help")
         }
         .alert("Could Not Open File", isPresented: Binding(
             get: { viewModel.errorMessage != nil },

--- a/apps/macos/ClearanceTests/Services/HelpCatalogTests.swift
+++ b/apps/macos/ClearanceTests/Services/HelpCatalogTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import Clearance
+
+final class HelpCatalogTests: XCTestCase {
+    private func writeTopic(_ name: String, contents: String, in dir: URL) throws -> URL {
+        let url = dir.appendingPathComponent(name)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    func testMakeTopicsSortsByOrderThenTitle() throws {
+        let dir = try makeTempDir()
+        let b = try writeTopic("b.md", contents: "---\ntitle: Bravo\norder: 2\n---\nbody b", in: dir)
+        let a = try writeTopic("a.md", contents: "---\ntitle: Alpha\norder: 1\n---\nbody a", in: dir)
+
+        let topics = HelpCatalog.makeTopics(from: [b, a])
+
+        XCTAssertEqual(topics.map(\.title), ["Alpha", "Bravo"])
+        XCTAssertEqual(topics.map(\.slug), ["a", "b"])
+        XCTAssertEqual(topics.first?.order, 1)
+    }
+
+    func testMakeTopicsSkipsFilesWithoutTitle() throws {
+        let dir = try makeTempDir()
+        let good = try writeTopic("good.md", contents: "---\ntitle: Good\norder: 1\n---\nbody", in: dir)
+        let bad = try writeTopic("bad.md", contents: "no frontmatter here", in: dir)
+
+        let topics = HelpCatalog.makeTopics(from: [good, bad])
+
+        XCTAssertEqual(topics.map(\.title), ["Good"])
+    }
+
+    func testMakeTopicsParsesBodyWithoutFrontmatter() throws {
+        let dir = try makeTempDir()
+        let url = try writeTopic("t.md", contents: "---\ntitle: T\norder: 1\n---\n# Heading\n\nsearchable body", in: dir)
+
+        let topics = HelpCatalog.makeTopics(from: [url])
+
+        XCTAssertEqual(topics.first?.body, "# Heading\n\nsearchable body")
+        XCTAssertFalse(topics.first?.body.contains("title: T") ?? true)
+    }
+
+    func testMakeTopicsSortsByTitleWhenOrderIsEqual() throws {
+        let dir = try makeTempDir()
+        _ = try writeTopic("zebra.md", contents: "---\ntitle: Zebra\norder: 1\n---\nbody", in: dir)
+        _ = try writeTopic("apple.md", contents: "---\ntitle: Apple\norder: 1\n---\nbody", in: dir)
+
+        let zebra = dir.appendingPathComponent("zebra.md")
+        let apple = dir.appendingPathComponent("apple.md")
+        let topics = HelpCatalog.makeTopics(from: [zebra, apple])
+
+        XCTAssertEqual(topics.map(\.title), ["Apple", "Zebra"])
+    }
+}

--- a/apps/macos/ClearanceTests/Services/HelpContentIntegrityTests.swift
+++ b/apps/macos/ClearanceTests/Services/HelpContentIntegrityTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Clearance
+
+final class HelpContentIntegrityTests: XCTestCase {
+    private func bundledTopics() -> [HelpTopic] {
+        let bundle = Bundle(for: HelpContentIntegrityTests.self)
+        let urls = bundle.urls(forResourcesWithExtension: "md", subdirectory: "Help") ?? []
+        return HelpCatalog.makeTopics(from: urls)
+    }
+
+    func testHelpFolderIsBundledAndEnumerable() {
+        // Fails if Help/ flattened instead of being a folder reference.
+        XCTAssertGreaterThanOrEqual(
+            bundledTopics().count, 12,
+            "Expected ≥12 help topics; folder-reference bundling may have flattened Help/ into the bundle root."
+        )
+    }
+
+    func testEveryTopicHasTitleAndOrder() {
+        // makeTopics skips files without a non-empty title; this guards that that filter stays in place.
+        for topic in bundledTopics() {
+            XCTAssertFalse(topic.title.isEmpty, topic.slug)
+            XCTAssertNotEqual(topic.order, Int.max, "missing/invalid order in \(topic.slug)")
+        }
+    }
+
+    func testOrdersAreUnique() {
+        let orders = bundledTopics().map(\.order)
+        XCTAssertEqual(orders.count, Set(orders).count, "duplicate order values")
+    }
+
+    func testEveryInternalMarkdownLinkResolvesToATopic() {
+        let topics = bundledTopics()
+        let known = Set(topics.map { $0.fileURL.deletingPathExtension().lastPathComponent })
+        let linkPattern = try! NSRegularExpression(pattern: #"\]\(([^)]+\.md)[^)]*\)"#)
+
+        for topic in topics {
+            let range = NSRange(topic.body.startIndex..., in: topic.body)
+            for match in linkPattern.matches(in: topic.body, range: range) {
+                guard let r = Range(match.range(at: 1), in: topic.body) else { continue }
+                let href = String(topic.body[r])
+                let linkedSlug = URL(fileURLWithPath: href).deletingPathExtension().lastPathComponent
+                XCTAssertTrue(known.contains(linkedSlug),
+                              "\(topic.slug) links to unknown help topic '\(href)'")
+            }
+        }
+    }
+
+    func testRenderedTopicsDoNotLeakFrontmatterMetadataBox() {
+        // The renderer shows frontmatter as a visible "Metadata" box for real
+        // documents; help topics must render via renderDocument (empty frontmatter)
+        // so the authoring-only title/order keys never appear on the page.
+        let builder = RenderedHTMLBuilder()
+        for topic in bundledTopics() {
+            let html = builder.build(document: topic.renderDocument)
+            XCTAssertFalse(html.contains("class=\"frontmatter\""), topic.slug)
+            XCTAssertFalse(html.contains(">Metadata<"), topic.slug)
+        }
+    }
+}

--- a/apps/macos/ClearanceTests/Services/HelpNavigationIntegrationTests.swift
+++ b/apps/macos/ClearanceTests/Services/HelpNavigationIntegrationTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import Clearance
+
+@MainActor
+final class HelpNavigationIntegrationTests: XCTestCase {
+    func testBundledRelativeLinkRoutesThroughRouterToTopic() throws {
+        let catalog = HelpCatalog(bundle: Bundle(for: HelpNavigationIntegrationTests.self))
+        let topics = catalog.topics()
+        XCTAssertGreaterThanOrEqual(topics.count, 12)
+
+        let source = try XCTUnwrap(topics.first(where: { $0.slug == "01-welcome" }))
+        let expectedTarget = try XCTUnwrap(topics.first(where: { $0.slug == "02-opening-files" }))
+
+        // Resolve "02-opening-files.md" the way WebKit resolves a relative href:
+        // against the source document's directory. WebKit delivers a fully-resolved
+        // absolute URL to the navigation delegate, so we call absoluteURL to match
+        // that behavior.
+        let baseDir = source.fileURL.deletingLastPathComponent()
+        let resolved = try XCTUnwrap(URL(string: "02-opening-files.md", relativeTo: baseDir))
+            .absoluteURL
+
+        // Route it the way RenderedMarkdownView's coordinator does.
+        let action = MarkdownLinkRouter.action(for: resolved, sourceDocumentURL: source.fileURL)
+        guard case let .openInApp(routedURL) = action else {
+            return XCTFail("expected .openInApp from the router, got \(action)")
+        }
+
+        // Feed the router's URL into the view model against real bundled topics.
+        let viewModel = HelpViewModel(topics: topics)
+        XCTAssertTrue(viewModel.openLink(routedURL),
+                      "router-produced URL must resolve to a known bundled topic")
+        XCTAssertEqual(viewModel.currentTopic?.slug, expectedTarget.slug)
+    }
+}

--- a/apps/macos/ClearanceTests/Services/HelpSearchIndexTests.swift
+++ b/apps/macos/ClearanceTests/Services/HelpSearchIndexTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import Clearance
+
+final class HelpSearchIndexTests: XCTestCase {
+    private func topic(_ slug: String, _ title: String, _ body: String) -> HelpTopic {
+        HelpTopic(
+            slug: slug,
+            title: title,
+            order: 0,
+            fileURL: URL(fileURLWithPath: "/Help/\(slug).md"),
+            body: body
+        )
+    }
+
+    func testReturnsEmptyForBlankQuery() {
+        let index = HelpSearchIndex(topics: [topic("a", "Alpha", "content")])
+        XCTAssertTrue(index.search("   ").isEmpty)
+    }
+
+    func testMatchesCaseInsensitively() {
+        let index = HelpSearchIndex(topics: [topic("open", "Opening Files", "Press Cmd-O to open a document")])
+        let results = index.search("OPEN")
+        XCTAssertEqual(results.map(\.topic.slug), ["open"])
+    }
+
+    func testRequiresAllTermsToMatch() {
+        let index = HelpSearchIndex(topics: [
+            topic("a", "Opening Files", "open a document"),
+            topic("b", "Editing", "edit text and save")
+        ])
+        XCTAssertEqual(index.search("open document").map(\.topic.slug), ["a"])
+        XCTAssertTrue(index.search("open zebra").isEmpty)
+    }
+
+    func testRanksTitleMatchesAboveBodyMatches() {
+        let index = HelpSearchIndex(topics: [
+            topic("body", "Printing", "you can search the whole document"),
+            topic("title", "Search", "find text on the page")
+        ])
+        let results = index.search("search")
+        XCTAssertEqual(results.first?.topic.slug, "title")
+    }
+
+    func testSnippetContainsQueryTerm() {
+        let index = HelpSearchIndex(topics: [topic("a", "Alpha", "the quick brown fox jumps")])
+        let snippet = index.search("brown").first?.snippet ?? ""
+        XCTAssertTrue(snippet.lowercased().contains("brown"))
+    }
+
+    func testSnippetIsEmptyForEmptyBody() {
+        let index = HelpSearchIndex(topics: [topic("a", "Empty", "")])
+        XCTAssertEqual(index.search("empty").first?.snippet, "")
+    }
+}

--- a/apps/macos/ClearanceTests/ViewModels/HelpViewModelTests.swift
+++ b/apps/macos/ClearanceTests/ViewModels/HelpViewModelTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Clearance
+
+@MainActor
+final class HelpViewModelTests: XCTestCase {
+    private func topic(_ slug: String, _ order: Int) -> HelpTopic {
+        HelpTopic(
+            slug: slug,
+            title: slug.capitalized,
+            order: order,
+            fileURL: URL(fileURLWithPath: "/Help/\(slug).md"),
+            body: "body \(slug)"
+        )
+    }
+
+    func testStartsOnFirstTopic() {
+        let vm = HelpViewModel(topics: [topic("welcome", 1), topic("opening", 2)])
+        XCTAssertEqual(vm.currentTopic?.slug, "welcome")
+        XCTAssertFalse(vm.canGoBack)
+    }
+
+    func testSelectPushesBackHistory() {
+        let vm = HelpViewModel(topics: [topic("welcome", 1), topic("opening", 2)])
+        vm.select(topic("opening", 2))
+        XCTAssertEqual(vm.currentTopic?.slug, "opening")
+        XCTAssertTrue(vm.canGoBack)
+        vm.goBack()
+        XCTAssertEqual(vm.currentTopic?.slug, "welcome")
+        XCTAssertTrue(vm.canGoForward)
+    }
+
+    func testOpenLinkNavigatesToMatchingTopicByPath() {
+        let topics = [topic("welcome", 1), topic("opening", 2)]
+        let vm = HelpViewModel(topics: topics)
+        let handled = vm.openLink(URL(fileURLWithPath: "/Help/opening.md"))
+        XCTAssertTrue(handled)
+        XCTAssertEqual(vm.currentTopic?.slug, "opening")
+    }
+
+    func testOpenLinkIgnoresUnknownAndNonFileLinks() {
+        let vm = HelpViewModel(topics: [topic("welcome", 1)])
+        XCTAssertFalse(vm.openLink(URL(fileURLWithPath: "/Help/missing.md")))
+        XCTAssertFalse(vm.openLink(URL(string: "https://example.com")!))
+        XCTAssertEqual(vm.currentTopic?.slug, "welcome")
+    }
+
+    func testRunSearchPopulatesResultsAndClearWhenBlank() {
+        let vm = HelpViewModel(topics: [topic("welcome", 1), topic("opening", 2)])
+        vm.searchQuery = "opening"
+        vm.runSearch()
+        XCTAssertEqual(vm.results.map(\.topic.slug), ["opening"])
+        vm.searchQuery = "   "
+        vm.runSearch()
+        XCTAssertTrue(vm.results.isEmpty)
+    }
+
+    func testOpenLinkToCurrentTopicReturnsTrueWithoutGrowingHistory() {
+        let vm = HelpViewModel(topics: [topic("welcome", 1), topic("opening", 2)])
+        XCTAssertTrue(vm.openLink(URL(fileURLWithPath: "/Help/welcome.md")))
+        XCTAssertEqual(vm.currentTopic?.slug, "welcome")
+        XCTAssertFalse(vm.canGoBack)
+    }
+
+    func testEmptyTopicsIsSafe() {
+        let vm = HelpViewModel(topics: [])
+        XCTAssertNil(vm.currentTopic)
+        XCTAssertFalse(vm.canGoBack)
+        XCTAssertFalse(vm.canGoForward)
+        vm.goBack()
+        vm.goForward()
+        XCTAssertNil(vm.currentTopic)
+        vm.searchQuery = "anything"
+        vm.runSearch()
+        XCTAssertTrue(vm.results.isEmpty)
+        XCTAssertFalse(vm.openLink(URL(fileURLWithPath: "/Help/x.md")))
+    }
+}

--- a/apps/macos/project.yml
+++ b/apps/macos/project.yml
@@ -19,6 +19,11 @@ targets:
     platform: macOS
     sources:
       - path: Clearance
+        excludes:
+          - Resources/Help
+      - path: Clearance/Resources/Help
+        type: folder
+        buildPhase: resources
       - path: CHANGELOG.md
         buildPhase: resources
     settings:
@@ -72,6 +77,9 @@ targets:
     platform: macOS
     sources:
       - path: ClearanceTests
+      - path: Clearance/Resources/Help
+        type: folder
+        buildPhase: resources
       - path: ../../packages/demo-corpus
         buildPhase: resources
     dependencies:


### PR DESCRIPTION
Adds an in-app help system: a Help window (opened from the Help menu) that renders bundled Markdown topics through the app's existing renderer, with a table-of-contents sidebar, cross-topic search, and in-help navigation. Replaces the system "Help isn't available" fallback.

Closes #53.

Tested with unit and integration tests for the catalog, search, view model, and content/navigation integrity; the full suite passes.
