### PR TITLE
Add --help flag and reject unsupported -- flags in the CLI

### DIFF
--- a/apps/macos/Clearance/Services/ClearanceCommandLineTool.swift
+++ b/apps/macos/Clearance/Services/ClearanceCommandLineTool.swift
@@ -11,6 +11,60 @@ enum ClearanceCommandLineTool {
     static let name = "clearance"
     static let appBundleIdentifier = "com.primeradiant.Clearance"
 
+    struct ParsedArguments: Equatable {
+        var helpRequested: Bool = false
+        var unsupportedFlags: [String] = []
+        var filePaths: [String] = []
+    }
+
+    static let helpText = """
+        clearance — open Markdown files in the Clearance app
+
+        usage: clearance [options] [files...]
+
+        options:
+          --help    Show this help and exit
+          --        Treat all following arguments as file paths
+
+        Files that don't exist yet are created as new Markdown documents.
+
+        examples:
+          clearance notes.md
+          clearance README.md CHANGELOG.md
+          clearance -- --weird-name.md
+        """
+
+    /// Splits raw CLI arguments (already dropping argv[0]) into help/flags/files.
+    /// Single left-to-right pass: `--help` sets the help flag, an exact `--`
+    /// switches everything after it to file paths, other `--`-prefixed tokens are
+    /// unsupported flags (never files), and anything else is a file path.
+    static func parseArguments(_ arguments: [String]) -> ParsedArguments {
+        var parsed = ParsedArguments()
+        var separatorSeen = false
+
+        for argument in arguments {
+            if separatorSeen {
+                parsed.filePaths.append(argument)
+                continue
+            }
+
+            switch argument {
+            case "--":
+                separatorSeen = true
+            case "--help":
+                parsed.helpRequested = true
+            default:
+                if argument.hasPrefix("--") {
+                    parsed.unsupportedFlags.append(argument)
+                } else {
+                    parsed.filePaths.append(argument)
+                }
+            }
+        }
+
+        return parsed
+    }
+
     static func helperExecutableURL(in bundle: Bundle = .main) -> URL? {
         let url = bundle.bundleURL
             .appending(path: "Contents", directoryHint: .isDirectory)

--- a/apps/macos/ClearanceCLI/main.swift
+++ b/apps/macos/ClearanceCLI/main.swift
@@ -8,13 +8,33 @@ do {
 }
 
 private func run() throws {
+    let parsed = ClearanceCommandLineTool.parseArguments(
+        Array(CommandLine.arguments.dropFirst())
+    )
+
+    if parsed.helpRequested {
+        print(ClearanceCommandLineTool.helpText)
+        exit(0)
+    }
+
+    for flag in parsed.unsupportedFlags {
+        FileHandle.standardError.write(
+            Data("\(ClearanceCommandLineTool.name): unsupported flag: \(flag)\n".utf8)
+        )
+    }
+
+    // Flag-only invocation (unsupported flag, no files): warn but do not launch.
+    if parsed.filePaths.isEmpty && !parsed.unsupportedFlags.isEmpty {
+        exit(0)
+    }
+
     guard let helperExecutableURL = Bundle.main.executableURL,
           let appURL = ClearanceCommandLineTool.appURL(forExecutableURL: helperExecutableURL) else {
         throw CommandError.appBundleNotFound
     }
 
     let documentURLs = try ClearanceCommandLineTool.prepareDocumentURLs(
-        forArguments: Array(CommandLine.arguments.dropFirst())
+        forArguments: parsed.filePaths
     )
 
     let process = Process()

--- a/apps/macos/ClearanceTests/Services/ClearanceCommandLineToolTests.swift
+++ b/apps/macos/ClearanceTests/Services/ClearanceCommandLineToolTests.swift
@@ -95,6 +95,112 @@ final class ClearanceCommandLineToolTests: XCTestCase {
         XCTAssertEqual(workspace.requestedBundleIdentifier, ClearanceCommandLineTool.appBundleIdentifier)
     }
 
+    func testParseArgumentsTreatsPlainPathsAsFiles() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["a.md", "b.md"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, ["a.md", "b.md"])
+    }
+
+    func testParseArgumentsDetectsHelpFlag() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--help"])
+
+        XCTAssertTrue(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, [])
+    }
+
+    func testParseArgumentsHelpFlagIsDetectedAlongsideFiles() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--help", "notes.md"])
+
+        XCTAssertTrue(parsed.helpRequested)
+        XCTAssertEqual(parsed.filePaths, ["notes.md"])
+    }
+
+    func testParseArgumentsCollectsUnsupportedFlagsWithoutCreatingFiles() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--foo", "notes.md"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, ["--foo"])
+        XCTAssertEqual(parsed.filePaths, ["notes.md"])
+    }
+
+    func testParseArgumentsFlagOnlyInvocationHasNoFilePaths() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--bogus"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, ["--bogus"])
+        XCTAssertEqual(parsed.filePaths, [])
+    }
+
+    func testParseArgumentsSeparatorTreatsFollowingArgumentsAsFiles() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--", "--weird-name.md"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, ["--weird-name.md"])
+    }
+
+    func testParseArgumentsHelpAfterSeparatorIsAFilePath() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--", "--help"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.filePaths, ["--help"])
+    }
+
+    func testParseArgumentsEmptyInputYieldsEmptyResult() {
+        let parsed = ClearanceCommandLineTool.parseArguments([])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, [])
+    }
+
+    func testParseArgumentsLoneSeparatorYieldsEmptyResult() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, [])
+    }
+
+    func testParseArgumentsSingleDashIsAFilePath() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["-"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, ["-"])
+    }
+
+    func testParseArgumentsDuplicateFlagsArePreservedInOrder() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--foo", "--foo"])
+
+        XCTAssertEqual(parsed.unsupportedFlags, ["--foo", "--foo"])
+        XCTAssertEqual(parsed.filePaths, [])
+    }
+
+    func testParseArgumentsOnlyFirstSeparatorIsHonored() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--", "a", "--", "b"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, ["a", "--", "b"])
+    }
+
+    func testParseArgumentsFlagThenSeparatorHasFlagButNoFiles() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--foo", "--"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, ["--foo"])
+        XCTAssertEqual(parsed.filePaths, [])
+    }
+
+    func testHelpTextDescribesUsage() {
+        XCTAssertTrue(ClearanceCommandLineTool.helpText.contains("usage:"))
+        XCTAssertTrue(ClearanceCommandLineTool.helpText.contains("--help"))
+    }
+
     private func makeBundle(helperName: String) throws -> URL {
         let rootURL = try makeDirectory().appendingPathExtension("app")
         let contentsURL = rootURL.appending(path: "Contents", directoryHint: .isDirectory)

--- a/docs/superpowers/plans/2026-06-20-cli-help-and-unsupported-flags.md
+++ b/docs/superpowers/plans/2026-06-20-cli-help-and-unsupported-flags.md
@@ -1,0 +1,367 @@
+# CLI `--help` and Unsupported-Flag Handling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `clearance` CLI print usage for `--help` and warn on unsupported `--flags` instead of creating files named after them, while still opening valid files.
+
+**Architecture:** Add a pure `parseArguments` function and a `helpText` string to the shared, unit-tested `ClearanceCommandLineTool` enum. Rewrite the untested `main.swift` glue to consume the parse result: help short-circuits to stdout, unsupported flags warn to stderr, flag-only invocations don't launch, and valid file paths flow into the existing `prepareDocumentURLs` + `open -a` path unchanged.
+
+**Tech Stack:** Swift 6, Xcode 26 (`xcodebuild`), XCTest. Build/test from `apps/macos`.
+
+---
+
+## File Structure
+
+- **Modify** `apps/macos/Clearance/Services/ClearanceCommandLineTool.swift` — add the `ParsedArguments` struct, `parseArguments(_:)`, and `helpText`. This file is compiled into both the `Clearance` app target and the `ClearanceCLI` tool target, so the CLI can call it.
+- **Modify** `apps/macos/ClearanceCLI/main.swift` — consume `parseArguments`; add help and flag-only early exits before app resolution.
+- **Modify** `apps/macos/ClearanceTests/Services/ClearanceCommandLineToolTests.swift` — add tests for `parseArguments` and `helpText`.
+
+## Build & Test Commands
+
+All run from `apps/macos`:
+
+- Build app: `xcodebuild -project Clearance.xcodeproj -scheme Clearance -configuration Debug -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO`
+- Run a single test class: `xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceCommandLineToolTests CODE_SIGNING_ALLOWED=NO`
+- Full suite: `xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
+
+> Note on `xcodebuild test` filtering: `-only-testing` runs just that class but still compiles the whole app + test bundle, so a compile error anywhere fails the run. Expect ~30–90s per run.
+
+---
+
+## Task 1: Argument parser and help text on `ClearanceCommandLineTool`
+
+**Files:**
+- Modify: `apps/macos/Clearance/Services/ClearanceCommandLineTool.swift`
+- Test: `apps/macos/ClearanceTests/Services/ClearanceCommandLineToolTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these tests inside the `ClearanceCommandLineToolTests` class (before the closing `}` and the `private` helpers), in `apps/macos/ClearanceTests/Services/ClearanceCommandLineToolTests.swift`:
+
+```swift
+    func testParseArgumentsTreatsPlainPathsAsFiles() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["a.md", "b.md"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, ["a.md", "b.md"])
+    }
+
+    func testParseArgumentsDetectsHelpFlag() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--help"])
+
+        XCTAssertTrue(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, [])
+    }
+
+    func testParseArgumentsHelpFlagIsDetectedAlongsideFiles() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--help", "notes.md"])
+
+        XCTAssertTrue(parsed.helpRequested)
+        XCTAssertEqual(parsed.filePaths, ["notes.md"])
+    }
+
+    func testParseArgumentsCollectsUnsupportedFlagsWithoutCreatingFiles() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--foo", "notes.md"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, ["--foo"])
+        XCTAssertEqual(parsed.filePaths, ["notes.md"])
+    }
+
+    func testParseArgumentsFlagOnlyInvocationHasNoFilePaths() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--bogus"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, ["--bogus"])
+        XCTAssertEqual(parsed.filePaths, [])
+    }
+
+    func testParseArgumentsSeparatorTreatsFollowingArgumentsAsFiles() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--", "--weird-name.md"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, ["--weird-name.md"])
+    }
+
+    func testParseArgumentsHelpAfterSeparatorIsAFilePath() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--", "--help"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.filePaths, ["--help"])
+    }
+
+    func testParseArgumentsEmptyInputYieldsEmptyResult() {
+        let parsed = ClearanceCommandLineTool.parseArguments([])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, [])
+    }
+
+    func testParseArgumentsLoneSeparatorYieldsEmptyResult() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, [])
+    }
+
+    func testParseArgumentsSingleDashIsAFilePath() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["-"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, ["-"])
+    }
+
+    func testParseArgumentsDuplicateFlagsArePreservedInOrder() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--foo", "--foo"])
+
+        XCTAssertEqual(parsed.unsupportedFlags, ["--foo", "--foo"])
+        XCTAssertEqual(parsed.filePaths, [])
+    }
+
+    func testParseArgumentsOnlyFirstSeparatorIsHonored() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--", "a", "--", "b"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, [])
+        XCTAssertEqual(parsed.filePaths, ["a", "--", "b"])
+    }
+
+    func testParseArgumentsFlagThenSeparatorHasFlagButNoFiles() {
+        let parsed = ClearanceCommandLineTool.parseArguments(["--foo", "--"])
+
+        XCTAssertFalse(parsed.helpRequested)
+        XCTAssertEqual(parsed.unsupportedFlags, ["--foo"])
+        XCTAssertEqual(parsed.filePaths, [])
+    }
+
+    func testHelpTextDescribesUsage() {
+        XCTAssertTrue(ClearanceCommandLineTool.helpText.contains("usage:"))
+        XCTAssertTrue(ClearanceCommandLineTool.helpText.contains("--help"))
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceCommandLineToolTests CODE_SIGNING_ALLOWED=NO`
+Expected: FAIL — compile error, `parseArguments`/`helpText`/`ParsedArguments` are undefined.
+
+- [ ] **Step 3: Implement `ParsedArguments`, `parseArguments`, and `helpText`**
+
+In `apps/macos/Clearance/Services/ClearanceCommandLineTool.swift`, add these members inside the `enum ClearanceCommandLineTool` body. Place them right after the existing `static let appBundleIdentifier = "com.primeradiant.Clearance"` line:
+
+```swift
+    struct ParsedArguments: Equatable {
+        var helpRequested: Bool = false
+        var unsupportedFlags: [String] = []
+        var filePaths: [String] = []
+    }
+
+    static let helpText = """
+        clearance — open Markdown files in the Clearance app
+
+        usage: clearance [options] [files...]
+
+        options:
+          --help    Show this help and exit
+          --        Treat all following arguments as file paths
+
+        Files that don't exist yet are created as new Markdown documents.
+
+        examples:
+          clearance notes.md
+          clearance README.md CHANGELOG.md
+          clearance -- --weird-name.md
+        """
+
+    static func parseArguments(_ arguments: [String]) -> ParsedArguments {
+        var parsed = ParsedArguments()
+        var separatorSeen = false
+
+        for argument in arguments {
+            if separatorSeen {
+                parsed.filePaths.append(argument)
+                continue
+            }
+
+            switch argument {
+            case "--":
+                separatorSeen = true
+            case "--help":
+                parsed.helpRequested = true
+            default:
+                if argument.hasPrefix("--") {
+                    parsed.unsupportedFlags.append(argument)
+                } else {
+                    parsed.filePaths.append(argument)
+                }
+            }
+        }
+
+        return parsed
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' -only-testing:ClearanceTests/ClearanceCommandLineToolTests CODE_SIGNING_ALLOWED=NO`
+Expected: PASS — all `ClearanceCommandLineToolTests` tests green, including the pre-existing ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/macos/Clearance/Services/ClearanceCommandLineTool.swift apps/macos/ClearanceTests/Services/ClearanceCommandLineToolTests.swift
+git commit -m "feat: parse CLI arguments for --help and unsupported flags"
+```
+
+---
+
+## Task 2: Wire `main.swift` to the parser
+
+**Files:**
+- Modify: `apps/macos/ClearanceCLI/main.swift`
+
+There is no unit test for `main.swift` (it is in neither test target — it is process-launch glue). Verification is a manual run of the built helper, defined in Step 4. The parsing logic it depends on is already covered by Task 1.
+
+- [ ] **Step 1: Rewrite `main.swift` control flow**
+
+Replace the entire body of `apps/macos/ClearanceCLI/main.swift` with the following. Key ordering: parse first, then handle `--help` and the flag-only case **before** resolving the app bundle, so help works even when the app cannot be located.
+
+```swift
+import Foundation
+
+do {
+    try run()
+} catch {
+    FileHandle.standardError.write(Data("\(ClearanceCommandLineTool.name): \(error.localizedDescription)\n".utf8))
+    exit(1)
+}
+
+private func run() throws {
+    let parsed = ClearanceCommandLineTool.parseArguments(
+        Array(CommandLine.arguments.dropFirst())
+    )
+
+    if parsed.helpRequested {
+        print(ClearanceCommandLineTool.helpText)
+        exit(0)
+    }
+
+    for flag in parsed.unsupportedFlags {
+        FileHandle.standardError.write(
+            Data("\(ClearanceCommandLineTool.name): unsupported flag: \(flag)\n".utf8)
+        )
+    }
+
+    // Flag-only invocation (no files): warn but do not launch the app.
+    if parsed.filePaths.isEmpty && !parsed.unsupportedFlags.isEmpty {
+        exit(0)
+    }
+
+    guard let helperExecutableURL = Bundle.main.executableURL,
+          let appURL = ClearanceCommandLineTool.appURL(forExecutableURL: helperExecutableURL) else {
+        throw CommandError.appBundleNotFound
+    }
+
+    let documentURLs = try ClearanceCommandLineTool.prepareDocumentURLs(
+        forArguments: parsed.filePaths
+    )
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+    process.arguments = ["-a", appURL.path] + documentURLs.map(\.path)
+    try process.run()
+    process.waitUntilExit()
+
+    guard process.terminationStatus == 0 else {
+        throw CommandError.openFailed(process.terminationStatus)
+    }
+}
+
+private enum CommandError: LocalizedError {
+    case appBundleNotFound
+    case openFailed(Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case .appBundleNotFound:
+            return "Could not locate \(ClearanceCommandLineTool.appBundleIdentifier)."
+        case .openFailed(let status):
+            return "`open` exited with status \(status)."
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build the app (which builds the embedded CLI helper)**
+
+Run: `xcodebuild -project Clearance.xcodeproj -scheme Clearance -configuration Debug -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO`
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Locate the built helper**
+
+The helper is at `<BUILT_PRODUCTS_DIR>/Clearance.app/Contents/Helpers/clearance`.
+Extract `BUILT_PRODUCTS_DIR` space-safely (anchor the line, split on ` = `, stop
+at the first match) and guard that the helper exists and is executable:
+
+```bash
+BPD="$(xcodebuild -project Clearance.xcodeproj -scheme Clearance -configuration Debug -destination 'platform=macOS' -showBuildSettings 2>/dev/null \
+  | awk -F' = ' '/^[[:space:]]*BUILT_PRODUCTS_DIR =/{print $2; exit}')"
+HELPER="$BPD/Clearance.app/Contents/Helpers/clearance"
+[ -x "$HELPER" ] && echo "helper OK: $HELPER" || { echo "MISSING helper at: $HELPER"; }
+```
+Expected: `helper OK: …/Clearance.app/Contents/Helpers/clearance`.
+
+- [ ] **Step 4: Manually verify the four behaviors**
+
+> These open the GUI Clearance.app, so run them on a logged-in macOS desktop
+> session (not headless/SSH), or `open` will fail and report a spurious exit 1.
+
+```bash
+# 1. Help prints usage to stdout and exits 0; opens nothing.
+"$HELPER" --help; echo "exit=$?"
+# Expected: usage text printed, exit=0.
+
+# 2. Unsupported flag warns on stderr; flag-only => no launch, exit 0.
+"$HELPER" --bogus; echo "exit=$?"
+# Expected: "clearance: unsupported flag: --bogus" on stderr, app does NOT launch, exit=0.
+
+# 3. Unsupported flag + valid file: warns, still opens the file, exit 0.
+TMP="$(mktemp -d)/note.md"; "$HELPER" --bogus "$TMP"; echo "exit=$?"
+# Expected: warning on stderr, Clearance opens with the new note.md, exit=0. File created at $TMP.
+
+# 4. `--` separator opens a dash-named file literally (no warning).
+DASHDIR="$(mktemp -d)"; ( cd "$DASHDIR" && "$HELPER" -- --weird-name.md ); echo "exit=$?"
+# Expected: no warning, Clearance opens, file "--weird-name.md" created in $DASHDIR, exit=0.
+ls -1 "$DASHDIR"
+```
+
+Confirm each `exit=` and the described side effects. (The dev helper opens the **dev** Clearance.app because the enclosing bundle wins over the Launch Services bundle-id lookup.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/macos/ClearanceCLI/main.swift
+git commit -m "feat: honor --help and unsupported flags in clearance CLI"
+```
+
+---
+
+## Task 3: Full regression run
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `xcodebuild test -project Clearance.xcodeproj -scheme Clearance -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
+Expected: `** TEST SUCCEEDED **`, zero failures. Confirms the new parser and `main.swift` changes did not regress existing `prepareDocumentURLs` / installer / app tests.
+
+- [ ] **Step 2: Confirm clean tree**
+
+Run: `git status --short`
+Expected: empty output (all changes committed across Tasks 1–2).

--- a/docs/superpowers/specs/2026-06-20-cli-help-and-unsupported-flags-design.md
+++ b/docs/superpowers/specs/2026-06-20-cli-help-and-unsupported-flags-design.md
@@ -1,0 +1,162 @@
+# CLI `--help` and Unsupported-Flag Handling — Design
+
+## Problem
+
+The `clearance` command-line helper passes every argument straight to
+`ClearanceCommandLineTool.prepareDocumentURLs`, which treats each argument as a
+file path and **creates a new Markdown file for any path that doesn't exist**.
+
+As a result:
+
+- `clearance --help` creates a file literally named `--help` and opens it,
+  instead of printing usage.
+- Any mistyped or unsupported `--flag` is silently turned into a new file.
+
+## Goals
+
+1. Add a `--help` flag that prints usage to stdout and exits 0 without opening
+   or creating anything.
+2. Treat any unrecognized `--`-prefixed argument as an unsupported flag: warn on
+   stderr and never turn it into a file.
+3. Still open the valid files in the same invocation (lenient handling).
+4. Honor the POSIX `--` separator so files whose names begin with dashes can
+   still be opened.
+
+## Non-Goals
+
+- Single-dash arguments (`-x`, `-`) are **not** in scope. They keep today's
+  behavior (treated as file paths). Only `--`-prefixed arguments are flags.
+- No `-h` alias and no `--version` flag — only `--help`.
+- No new argument-parsing dependency (e.g. swift-argument-parser).
+
+## Behavior Specification
+
+Given the arguments after the executable name (`CommandLine.arguments.dropFirst()`):
+
+| Argument pattern                         | Treatment                                                        |
+| ---------------------------------------- | --------------------------------------------------------------- |
+| `--help`                                 | Sets "help requested"                                           |
+| `--` (first literal occurrence)          | Separator: every argument **after** it is a file path           |
+| `--anything-else` (before any `--`)      | Unsupported flag — collected, never becomes a file              |
+| Anything not starting with `--`          | File path                                                       |
+| Anything (incl. `--foo`) **after** `--`  | File path (literal)                                             |
+
+### Resolution order in `main.swift`
+
+1. **Help wins and short-circuits.** If "help requested" is set, print the help
+   text to **stdout** and `exit(0)`. No files are opened or created, even if
+   valid file arguments are present (`clearance --help notes.md` just prints
+   help).
+2. **Warn about unsupported flags.** For each collected unsupported flag, write
+   `clearance: unsupported flag: <flag>` to **stderr**.
+3. **Suppress flag-only launch.** If `filePaths` is empty **and** at least one
+   unsupported flag was present (e.g. `clearance --bogus`), do **not** launch the
+   app — only the warning(s) from step 2 are emitted. `exit(0)`.
+4. **Open / launch.** Otherwise call the existing `prepareDocumentURLs` with
+   `filePaths` and `open -a` the app. When `filePaths` is non-empty those files
+   open; when it is empty (bare `clearance`, or `clearance --`) the app launches
+   with no document — preserving today's behavior.
+5. **Exit 0** in all non-help, non-error cases — including when unsupported
+   flags were warned about but valid files opened successfully. A genuine
+   failure to launch (`open` non-zero) still exits 1 as today.
+
+The launch-suppression condition is precisely `filePaths.isEmpty &&
+!unsupportedFlags.isEmpty`. This preserves the bare-`clearance` launch (no
+flags, no files) while suppressing the surprising empty launch when the user
+clearly intended a flag.
+
+### Help text
+
+Printed to stdout, exit 0:
+
+```
+clearance — open Markdown files in the Clearance app
+
+usage: clearance [options] [files...]
+
+options:
+  --help    Show this help and exit
+  --        Treat all following arguments as file paths
+
+Files that don't exist yet are created as new Markdown documents.
+
+examples:
+  clearance notes.md
+  clearance README.md CHANGELOG.md
+  clearance -- --weird-name.md
+```
+
+## Architecture
+
+All parsing logic goes into the shared, already-unit-tested
+`ClearanceCommandLineTool` enum
+(`apps/macos/Clearance/Services/ClearanceCommandLineTool.swift`). That file is
+compiled into both the `Clearance` app target and the `ClearanceCLI` tool
+target, and is exercised by `ClearanceCommandLineToolTests`. Keeping logic there
+(rather than in `main.swift`, which is in neither test target) makes it
+testable.
+
+### New API on `ClearanceCommandLineTool`
+
+```swift
+struct ParsedArguments: Equatable {
+    var helpRequested: Bool
+    var unsupportedFlags: [String]
+    var filePaths: [String]
+}
+
+static func parseArguments(_ arguments: [String]) -> ParsedArguments
+
+static let helpText: String
+```
+
+`parseArguments` is a pure function: no I/O, no filesystem, no process launch. It
+fully determines control flow from the argument list alone.
+
+### `main.swift` changes
+
+`main.swift` (in `ClearanceCLI`, untested glue) becomes:
+
+1. `let parsed = ClearanceCommandLineTool.parseArguments(Array(CommandLine.arguments.dropFirst()))`
+2. If `parsed.helpRequested`: print `helpText` to stdout, `exit(0)`.
+3. For each flag in `parsed.unsupportedFlags`: write
+   `\(name): unsupported flag: \(flag)\n` to stderr.
+4. If `parsed.filePaths.isEmpty && !parsed.unsupportedFlags.isEmpty`: `exit(0)`
+   (flag-only invocation, no launch).
+5. Otherwise resolve the helper/app URLs, call
+   `prepareDocumentURLs(forArguments: parsed.filePaths)`, and `open -a` as today
+   (with an empty `filePaths` this launches the app with no document, as before).
+
+The existing app-bundle-resolution and `open` logic is unchanged; only the input
+to `prepareDocumentURLs` is now the filtered `filePaths`, and two early exits are
+added (help, empty-after-flags).
+
+## Testing
+
+Add to `ClearanceTests/Services/ClearanceCommandLineToolTests.swift` (TDD — write
+failing tests first):
+
+1. `--help` anywhere sets `helpRequested` and yields no file paths/flags.
+2. `--help notes.md` sets `helpRequested` (help short-circuits; file paths may
+   still be collected but are irrelevant because main exits early).
+3. An unsupported flag (`--foo`) lands in `unsupportedFlags`, not `filePaths`.
+4. `--foo notes.md` → `unsupportedFlags == ["--foo"]`, `filePaths == ["notes.md"]`.
+5. `--bogus` alone → `unsupportedFlags == ["--bogus"]`, `filePaths == []`,
+   `helpRequested == false` (drives the no-launch path).
+6. `--` separator: `-- --weird-name.md` → `filePaths == ["--weird-name.md"]`,
+   no unsupported flags, no help.
+7. `--help` appearing **after** `--` is a file path, not help
+   (`-- --help` → `filePaths == ["--help"]`).
+8. Plain paths with no flags are unchanged (`a.md b.md` → `filePaths` both, no
+   flags/help) — guards the existing happy path.
+9. `helpText` is non-empty and contains `usage:` (cheap regression guard on the
+   message).
+
+The existing `prepareDocumentURLs` tests remain valid and unchanged, since that
+function's contract is untouched — it just receives pre-filtered paths.
+
+## Out of Scope / Future
+
+- UI changes to the main SwiftUI app are tracked separately (their own
+  brainstorm → spec → worktree → PR cycle).
+```

--- a/docs/superpowers/specs/2026-06-20-cli-help-and-unsupported-flags-design.md
+++ b/docs/superpowers/specs/2026-06-20-cli-help-and-unsupported-flags-design.md
@@ -36,12 +36,36 @@ Given the arguments after the executable name (`CommandLine.arguments.dropFirst(
 | Argument pattern                         | Treatment                                                        |
 | ---------------------------------------- | --------------------------------------------------------------- |
 | `--help`                                 | Sets "help requested"                                           |
-| `--` (first literal occurrence)          | Separator: every argument **after** it is a file path           |
+| `--` (exactly two dashes, first one)     | Separator: every argument **after** it is a file path           |
 | `--anything-else` (before any `--`)      | Unsupported flag — collected, never becomes a file              |
 | Anything not starting with `--`          | File path                                                       |
 | Anything (incl. `--foo`) **after** `--`  | File path (literal)                                             |
 
+**Parsing-contract details (so the implementation is unambiguous):**
+
+- The separator is matched by **exact equality** to `--`. `---` (three dashes)
+  is not the separator — it starts with `--` and isn't `--help`, so it is an
+  **unsupported flag**. A single `-` does not start with `--`, so it is a
+  **file path** (consistent with the non-goal of leaving single-dash args
+  alone).
+- Parsing is a single left-to-right pass that **always populates all three
+  fields** regardless of what else is present. `helpRequested` does **not**
+  blank out `filePaths`/`unsupportedFlags`; e.g. `parseArguments(["--help",
+  "notes.md"])` returns `helpRequested == true` **and** `filePaths ==
+  ["notes.md"]`. The short-circuit that ignores those file paths happens later,
+  in `main.swift` (step 1 below), not in the parser.
+- Unsupported flags are collected **in argument order and not de-duplicated**:
+  `--foo --foo` yields `["--foo", "--foo"]` and produces two warnings. This
+  keeps the parser a trivial, order-preserving pass.
+- Only the **first** `--` is the separator; a later `--` after the separator is
+  just a file path (so `-- a -- b` yields file paths `["a", "--", "b"]`).
+
 ### Resolution order in `main.swift`
+
+These steps run **in order, and the help and flag-only exits occur *before* the
+app bundle is located.** Locating the app can fail (`appBundleNotFound`); `--help`
+must still print and exit 0 on a broken/uninstalled app, so bundle resolution
+must not run for the help or flag-only paths.
 
 1. **Help wins and short-circuits.** If "help requested" is set, print the help
    text to **stdout** and `exit(0)`. No files are opened or created, even if
@@ -63,7 +87,16 @@ Given the arguments after the executable name (`CommandLine.arguments.dropFirst(
 The launch-suppression condition is precisely `filePaths.isEmpty &&
 !unsupportedFlags.isEmpty`. This preserves the bare-`clearance` launch (no
 flags, no files) while suppressing the surprising empty launch when the user
-clearly intended a flag.
+clearly intended a flag. The condition takes precedence over the `--`
+separator: `clearance --foo --` has an unsupported flag and no files, so it
+warns and does **not** launch — an erroneous flag with nothing to open is
+treated as an error case regardless of a trailing `--`. (Plain `clearance --`,
+with no flags, still launches bare.)
+
+**Exit codes are exit 0 for every non-launch-failure case**, including the
+flag-only warn-and-don't-launch path. This is a deliberate, user-chosen
+behavior (lenient: a warning is emitted but the process still reports success);
+the only non-zero exit is the pre-existing `open` failure (exit 1).
 
 ### Help text
 
@@ -136,9 +169,12 @@ added (help, empty-after-flags).
 Add to `ClearanceTests/Services/ClearanceCommandLineToolTests.swift` (TDD — write
 failing tests first):
 
-1. `--help` anywhere sets `helpRequested` and yields no file paths/flags.
-2. `--help notes.md` sets `helpRequested` (help short-circuits; file paths may
-   still be collected but are irrelevant because main exits early).
+1. `--help` alone → `helpRequested == true`, `filePaths == []`,
+   `unsupportedFlags == []`.
+2. `--help notes.md` → `helpRequested == true` **and** `filePaths ==
+   ["notes.md"]` (the parser still collects the path; `main` short-circuits on
+   help). Asserting `filePaths` here pins the contract rather than leaving it
+   vacuous.
 3. An unsupported flag (`--foo`) lands in `unsupportedFlags`, not `filePaths`.
 4. `--foo notes.md` → `unsupportedFlags == ["--foo"]`, `filePaths == ["notes.md"]`.
 5. `--bogus` alone → `unsupportedFlags == ["--bogus"]`, `filePaths == []`,
@@ -149,8 +185,18 @@ failing tests first):
    (`-- --help` → `filePaths == ["--help"]`).
 8. Plain paths with no flags are unchanged (`a.md b.md` → `filePaths` both, no
    flags/help) — guards the existing happy path.
-9. `helpText` is non-empty and contains `usage:` (cheap regression guard on the
-   message).
+9. Empty input (`[]`) → all three fields empty/false (the bare-`clearance`
+   launch path).
+10. Lone `--` (`["--"]`) → all empty (separator with nothing after; bare
+    launch).
+11. Single `-` (`["-"]`) → `filePaths == ["-"]` (single-dash stays a file path,
+    per non-goals).
+12. Duplicate flags (`["--foo", "--foo"]`) → `unsupportedFlags == ["--foo",
+    "--foo"]` (order preserved, not de-duplicated).
+13. Multiple `--` (`["--", "a", "--", "b"]`) → `filePaths == ["a", "--", "b"]`
+    (only the first `--` is the separator).
+14. `helpText` is non-empty and contains both `usage:` and `--help` (cheap
+    regression guard on the message).
 
 The existing `prepareDocumentURLs` tests remain valid and unchanged, since that
 function's contract is untouched — it just receives pre-filtered paths.


### PR DESCRIPTION
 The `clearance` CLI passes every argument straight to file handling, which *creates a new Markdown file* for any path that does not exist. As a result `clearance --help` creates a file literally named `--help`, and any mistyped `--flag` is silently turned into a file.

## Change
- `--help` prints usage to stdout and exits 0 without opening anything.
- Unrecognized `--` flags print `clearance: unsupported flag: <flag>` to stderr and are never turned into files; valid files in the same command still open.
- A flag-only invocation (e.g. `clearance --bogus`) warns and does not launch the app.
- The POSIX `--` separator is honored, so files whose names start with dashes can still be opened. Bare `clearance` still launches the app.

Parsing lives in the shared, unit-tested `ClearanceCommandLineTool`; `main.swift` stays thin glue.

## Testing
- 13 new unit tests for the argument parser (help, unsupported flags, `--` separator, dedup/order, single-dash, empty input).
- Full suite: 195 tests, 0 failures.
- Manually verified all behaviors against the built helper.

Includes a design spec and implementation plan under `docs/superpowers/`, matching the repo's existing convention.